### PR TITLE
fix(repl): pass process object to MCP send-string (gh#11)

### DIFF
--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1350,6 +1350,34 @@
   (require 'unison-ts-repl)
   (should (fboundp 'unison-ts-mcp--run)))
 
+(ert-deftest unison-ts-mcp/async-uses-process-object-not-name ()
+  "Async branch must pass the process object to process-send-string/eof, not the name string (gh#11).
+
+When Emacs auto-uniquifies the process name (e.g. ucm-mcp<2>), sending to the
+string \"ucm-mcp\" hits a dead process.  Binding the return value of
+make-process and using it directly eliminates both the name-collision and the
+stale-lookup failure modes."
+  (require 'unison-ts-repl)
+  (require 'cl-lib)
+  (let ((fake-proc (start-process "test-fake-mcp" nil "true"))
+        (send-string-targets nil)
+        (send-eof-targets nil))
+    (cl-letf (((symbol-function 'make-process)
+               (lambda (&rest _args) fake-proc))
+              ((symbol-function 'process-send-string)
+               (lambda (proc _string)
+                 (push proc send-string-targets)))
+              ((symbol-function 'process-send-eof)
+               (lambda (proc)
+                 (push proc send-eof-targets))))
+      (unison-ts-mcp--call '(("noop" . nil)) (lambda (_) nil)))
+    (should send-string-targets)
+    (should send-eof-targets)
+    (should (cl-every (lambda (target) (eq target fake-proc)) send-string-targets))
+    (should (cl-every (lambda (target) (eq target fake-proc)) send-eof-targets))
+    (should (cl-notany (lambda (target) (stringp target)) send-string-targets))
+    (should (cl-notany (lambda (target) (stringp target)) send-eof-targets))))
+
 ;;; Inferior UCM (gh#8) — full UCM in a comint buffer, no separate `ucm headless'
 
 (ert-deftest unison-ts-inferior/mode-defined ()

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -87,24 +87,24 @@ If CALLBACK is nil, runs synchronously and returns responses."
          (input (mapconcat #'json-encode all-requests "\n")))
     (if callback
         ;; Async mode
-        (let ((output-buffer (generate-new-buffer " *ucm-mcp-output*")))
-          (make-process
-           :name "ucm-mcp"
-           :buffer output-buffer
-           :command (list unison-ts-ucm-executable "mcp")
-           :connection-type 'pipe
-           :sentinel (lambda (proc _event)
-                       (when (memq (process-status proc) '(exit signal))
-                         (let ((responses (unison-ts-mcp--parse-output output-buffer)))
-                           (kill-buffer output-buffer)
-                           (funcall callback responses))))
-           :filter (lambda (proc string)
-                     (with-current-buffer (process-buffer proc)
-                       (goto-char (point-max))
-                       (insert string))))
-          (process-send-string "ucm-mcp" input)
-          (process-send-string "ucm-mcp" "\n")
-          (process-send-eof "ucm-mcp")
+        (let* ((output-buffer (generate-new-buffer " *ucm-mcp-output*"))
+               (proc (make-process
+                      :name "ucm-mcp"
+                      :buffer output-buffer
+                      :command (list unison-ts-ucm-executable "mcp")
+                      :connection-type 'pipe
+                      :sentinel (lambda (proc _event)
+                                  (when (memq (process-status proc) '(exit signal))
+                                    (let ((responses (unison-ts-mcp--parse-output output-buffer)))
+                                      (kill-buffer output-buffer)
+                                      (funcall callback responses))))
+                      :filter (lambda (proc string)
+                                (with-current-buffer (process-buffer proc)
+                                  (goto-char (point-max))
+                                  (insert string))))))
+          (process-send-string proc input)
+          (process-send-string proc "\n")
+          (process-send-eof proc)
           nil)
       ;; Sync mode (for REPL)
       (let ((output (with-temp-buffer


### PR DESCRIPTION
closes #11

`make-process` return value was discarded; subsequent `process-send-string` and `process-send-eof` calls used the string `"ucm-mcp"` as a lookup key. when emacs auto-uniquifies the name (e.g. `ucm-mcp<2>` after a finished process lingers), the sends hit the wrong dead process.

fix: bind the `make-process` result and pass the object directly.

regression test (`unison-ts-mcp/async-uses-process-object-not-name`) stubs `make-process` to return a known sentinel object, then asserts every `process-send-string`/`process-send-eof` first argument is that object and not the string `"ucm-mcp"`.