### PR TITLE
fix(repl): use project-current for project root (gh#13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Navigate to functions, types, and abilities:
 
 ### LSP Support
 
-Requires [UCM](https://www.unison-lang.org/docs/install-instructions/). UCM auto-starts in headless mode when you open a `.u` file.
+Requires [UCM](https://www.unison-lang.org/docs/install-instructions/). UCM auto-starts as the inferior UCM (full TUI in a comint buffer) the first time eglot, lsp-mode, or the REPL needs it. The same process serves LSP, MCP, and the user-facing TUI, so there is no codebase-lock conflict.
 
 **Eglot (built-in Emacs 29+):**
 
@@ -134,8 +134,10 @@ export UNISON_LSP_PORT=5758
 
 **Manual UCM:**
 
+If you would rather manage UCM yourself, just start it before connecting (Emacs detects it on the LSP port and skips the auto-spawn):
+
 ```bash
-ucm headless
+ucm
 ```
 
 ### UCM Integration
@@ -144,7 +146,8 @@ Interact with UCM directly from Emacs. Open the REPL with `C-c C-u r` or use the
 
 | Keybinding | Command | Description |
 |------------|---------|-------------|
-| `C-c C-u r` | `unison-ts-repl` | Open UCM REPL |
+| `C-c C-u r` | `unison-ts-repl` | Open UCM REPL (MCP-based) |
+| `C-c C-u i` | `unison-ts-inferior-ucm` | Open the inferior UCM (full TUI) |
 | `C-c C-u a` | `unison-ts-add` | Add definitions from current file |
 | `C-c C-u u` | `unison-ts-update` | Update existing definitions |
 | `C-c C-u t` | `unison-ts-test` | Run tests (prompts for pattern) |

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1418,6 +1418,26 @@ TUI inside Emacs."
       (when (process-live-p proc)
         (delete-process proc)))))
 
+(ert-deftest unison-ts-inferior/start-errors-when-process-not-attached ()
+  "If `make-comint-in-buffer' does not attach a process, error out and
+do not leak the buffer.  Regression test for the partial-spawn path."
+  (require 'unison-ts-repl)
+  (require 'cl-lib)
+  (let ((unison-ts-ucm-executable "true")
+        (unison-ts-lsp-port 1)
+        (unison-ts-inferior-ucm-buffer-name "*ucm-test-no-proc*")
+        (unison-ts--ucm-process nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'make-comint-in-buffer)
+                   (lambda (_name _buffer _program _startfile &rest _switches)
+                     ;; Return a buffer with no attached process.
+                     (get-buffer-create unison-ts-inferior-ucm-buffer-name))))
+          (should-error (unison-ts--start-ucm-inferior) :type 'error)
+          (should (null unison-ts--ucm-process))
+          (should-not (get-buffer unison-ts-inferior-ucm-buffer-name)))
+      (when-let ((b (get-buffer unison-ts-inferior-ucm-buffer-name)))
+        (kill-buffer b)))))
+
 (ert-deftest unison-ts-inferior/cleanup-kills-buffer ()
   "Cleanup also kills the inferior UCM buffer (avoids stale buffer)."
   (require 'unison-ts-repl)

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1265,10 +1265,22 @@
 ;;; REPL integration tests
 
 (ert-deftest unison-ts-repl/project-root-fallback ()
-  "Project root should fall back to default-directory."
+  "Project root should fall back to default-directory when no project is found."
   (require 'unison-ts-repl)
-  (let ((default-directory "/tmp/"))
-    (should (equal (unison-ts-project-root) "/tmp/"))))
+  (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
+    (let ((default-directory "/tmp/"))
+      (should (equal (unison-ts-project-root) "/tmp/")))))
+
+(ert-deftest unison-ts-repl/project-root-prefers-project-current ()
+  "Project root should return project-root when project-current succeeds."
+  (require 'unison-ts-repl)
+  (cl-letf (((symbol-function 'project-current)
+             (lambda (&rest _)
+               (cons 'transient "/tmp/some-proj/")))
+            ((symbol-function 'project-root)
+             (lambda (_proj) "/tmp/some-proj/")))
+    (let ((default-directory "/tmp/some-proj/src/"))
+      (should (equal (unison-ts-project-root) "/tmp/some-proj/")))))
 
 (ert-deftest unison-ts-repl/project-name ()
   "Project name should be directory name."

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1430,6 +1430,30 @@ TUI inside Emacs."
           (should-not (buffer-live-p buf)))
       (when (buffer-live-p buf) (kill-buffer buf)))))
 
+(ert-deftest unison-ts-inferior/mode-set-before-process-attach ()
+  "Mode must be active before `make-comint-in-buffer' starts the process.
+This avoids a race where `define-derived-mode' \\='s
+`kill-all-local-variables' blanks `comint-last-output-start' while
+UCM is already emitting output, which crashes any `:after' advice
+on `comint-output-filter' that reads the marker (e.g. Doom's
+`doom--comint-enable-undo-a').  Regression test for the
+`Wrong type argument: number-or-marker-p, nil' bug."
+  (require 'unison-ts-repl)
+  (require 'cl-lib)
+  (let ((mode-at-attach nil)
+        (unison-ts-ucm-executable "true")
+        (unison-ts-lsp-port 1)
+        (unison-ts-inferior-ucm-buffer-name "*ucm-test-order*"))
+    (cl-letf (((symbol-function 'make-comint-in-buffer)
+               (lambda (_name buffer _program _startfile &rest _switches)
+                 (let ((buf (if (bufferp buffer) buffer (get-buffer-create buffer))))
+                   (with-current-buffer buf
+                     (setq mode-at-attach major-mode))
+                   buf)))
+              ((symbol-function 'sit-for) (lambda (&rest _) t)))
+      (condition-case _ (unison-ts--start-ucm-inferior) (error nil)))
+    (should (provided-mode-derived-p mode-at-attach 'unison-ts-inferior-ucm-mode))))
+
 (ert-deftest unison-ts-inferior/start-failure-clears-state ()
   "When UCM never opens the LSP port, cleanup runs and the var clears."
   (require 'unison-ts-repl)

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1350,5 +1350,98 @@
   (require 'unison-ts-repl)
   (should (fboundp 'unison-ts-mcp--run)))
 
+;;; Inferior UCM (gh#8) — full UCM in a comint buffer, no separate `ucm headless'
+
+(ert-deftest unison-ts-inferior/mode-defined ()
+  "Inferior UCM major mode should be defined and derive from comint-mode."
+  (require 'unison-ts-repl)
+  (should (fboundp 'unison-ts-inferior-ucm-mode))
+  (should (provided-mode-derived-p 'unison-ts-inferior-ucm-mode 'comint-mode)))
+
+(ert-deftest unison-ts-inferior/command-defined ()
+  "Interactive entry point should exist."
+  (require 'unison-ts-repl)
+  (should (fboundp 'unison-ts-inferior-ucm))
+  (should (commandp 'unison-ts-inferior-ucm)))
+
+(ert-deftest unison-ts-inferior/buffer-name-defcustom ()
+  "Buffer name should be a configurable string defcustom."
+  (require 'unison-ts-repl)
+  (should (boundp 'unison-ts-inferior-ucm-buffer-name))
+  (should (stringp unison-ts-inferior-ucm-buffer-name))
+  (should (eq (get 'unison-ts-inferior-ucm-buffer-name 'custom-type) 'string)))
+
+(ert-deftest unison-ts-inferior/keybinding ()
+  "C-c C-u i should invoke inferior UCM."
+  (require 'unison-ts-mode)
+  (should (eq (lookup-key unison-ts-mode-map (kbd "C-c C-u i"))
+              'unison-ts-inferior-ucm)))
+
+(ert-deftest unison-ts-inferior/spawns-full-ucm-not-headless ()
+  "Spawn function must invoke `ucm' without the `headless' sub-command (gh#8).
+
+`ucm headless' grabs the codebase lock and prevents the user from
+running `ucm' externally.  A full `ucm' invocation exposes the
+same LSP/MCP endpoints while letting the user interact with the
+TUI inside Emacs."
+  (require 'unison-ts-repl)
+  (require 'cl-lib)
+  (let ((captured-args nil)
+        (unison-ts-ucm-executable "true")
+        ;; Pick a port that the real `unison-ts-api--port-open-p' will
+        ;; report as closed, so we exercise the spawn branch for real.
+        (unison-ts-lsp-port 1))
+    (cl-letf (((symbol-function 'make-comint-in-buffer)
+               (lambda (name buffer program _startfile &rest switches)
+                 (setq captured-args (cons program switches))
+                 (get-buffer-create (if (stringp buffer)
+                                        buffer
+                                      (format "*%s*" name)))))
+              ((symbol-function 'sit-for) (lambda (&rest _) t)))
+      (condition-case _
+          (unison-ts--start-ucm-inferior)
+        (error nil)))
+    (should captured-args)
+    (should-not (member "headless" (cdr captured-args)))))
+
+(ert-deftest unison-ts-inferior/cleanup-on-emacs-exit ()
+  "Inferior UCM process is torn down on Emacs exit."
+  (require 'unison-ts-repl)
+  (should (memq 'unison-ts--cleanup-ucm kill-emacs-hook))
+  (let ((proc (start-process "test-ucm-fake" nil "sleep" "30")))
+    (unwind-protect
+        (let ((unison-ts--ucm-process proc))
+          (should (process-live-p proc))
+          (unison-ts--cleanup-ucm)
+          (should-not (process-live-p proc))
+          (should (null unison-ts--ucm-process)))
+      (when (process-live-p proc)
+        (delete-process proc)))))
+
+(ert-deftest unison-ts-inferior/cleanup-kills-buffer ()
+  "Cleanup also kills the inferior UCM buffer (avoids stale buffer)."
+  (require 'unison-ts-repl)
+  (let* ((unison-ts-inferior-ucm-buffer-name "*ucm-test-cleanup*")
+         (buf (get-buffer-create unison-ts-inferior-ucm-buffer-name)))
+    (unwind-protect
+        (let ((unison-ts--ucm-process nil))
+          (should (buffer-live-p buf))
+          (unison-ts--cleanup-ucm)
+          (should-not (buffer-live-p buf)))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(ert-deftest unison-ts-inferior/start-failure-clears-state ()
+  "When UCM never opens the LSP port, cleanup runs and the var clears."
+  (require 'unison-ts-repl)
+  (require 'cl-lib)
+  (let* ((unison-ts-ucm-executable "true")
+         (unison-ts-lsp-port 1)
+         (unison-ts-inferior-ucm-buffer-name "*ucm-test-failure*")
+         (unison-ts--ucm-process nil))
+    (cl-letf (((symbol-function 'sit-for) (lambda (&rest _) t)))
+      (should-error (unison-ts--start-ucm-inferior) :type 'error))
+    (should (null unison-ts--ucm-process))
+    (should-not (get-buffer unison-ts-inferior-ucm-buffer-name))))
+
 (provide 'unison-ts-mode-tests)
 ;;; unison-ts-mode-tests.el ends here

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1350,6 +1350,34 @@
   (require 'unison-ts-repl)
   (should (fboundp 'unison-ts-mcp--run)))
 
+(ert-deftest unison-ts-mcp/async-uses-process-object-not-name ()
+  "Async branch must pass the process object to process-send-string/eof, not the name string (gh#11).
+
+When Emacs auto-uniquifies the process name (e.g. ucm-mcp<2>), sending to the
+string \"ucm-mcp\" hits a dead process.  Binding the return value of
+make-process and using it directly eliminates both the name-collision and the
+stale-lookup failure modes."
+  (require 'unison-ts-repl)
+  (require 'cl-lib)
+  (let ((fake-proc (start-process "test-fake-mcp" nil "true"))
+        (send-string-targets nil)
+        (send-eof-targets nil))
+    (cl-letf (((symbol-function 'make-process)
+               (lambda (&rest _args) fake-proc))
+              ((symbol-function 'process-send-string)
+               (lambda (proc _string)
+                 (push proc send-string-targets)))
+              ((symbol-function 'process-send-eof)
+               (lambda (proc)
+                 (push proc send-eof-targets))))
+      (unison-ts-mcp--call '(("noop" . nil)) (lambda (_) nil)))
+    (should send-string-targets)
+    (should send-eof-targets)
+    (should (cl-every (lambda (target) (eq target fake-proc)) send-string-targets))
+    (should (cl-every (lambda (target) (eq target fake-proc)) send-eof-targets))
+    (should (cl-notany (lambda (target) (stringp target)) send-string-targets))
+    (should (cl-notany (lambda (target) (stringp target)) send-eof-targets))))
+
 ;;; Inferior UCM (gh#8) — full UCM in a comint buffer, no separate `ucm headless'
 
 (ert-deftest unison-ts-inferior/mode-defined ()

--- a/unison-ts-mode.el
+++ b/unison-ts-mode.el
@@ -44,7 +44,8 @@
 ;; eglot or lsp-mode.
 ;;
 ;; UCM Keybindings (under C-c C-u prefix):
-;;   C-c C-u r - Open UCM REPL
+;;   C-c C-u r - Open UCM REPL (MCP-based)
+;;   C-c C-u i - Open inferior UCM (full TUI)
 ;;   C-c C-u a - Add definitions from current file
 ;;   C-c C-u u - Update definitions
 ;;   C-c C-u t - Run tests
@@ -126,6 +127,7 @@ See `treesit-simple-imenu-settings' for details.")
 (defvar unison-ts-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-u r") #'unison-ts-repl)
+    (define-key map (kbd "C-c C-u i") #'unison-ts-inferior-ucm)
     (define-key map (kbd "C-c C-u a") #'unison-ts-add)
     (define-key map (kbd "C-c C-u u") #'unison-ts-update)
     (define-key map (kbd "C-c C-u t") #'unison-ts-test)
@@ -142,6 +144,7 @@ See `treesit-simple-imenu-settings' for details.")
   "Menu for Unison mode."
   '("Unison"
     ["Open UCM REPL" unison-ts-repl]
+    ["Open Inferior UCM (full TUI)" unison-ts-inferior-ucm]
     "---"
     ("UCM Commands"
      ["Add" unison-ts-add :active buffer-file-name]
@@ -188,29 +191,14 @@ See `treesit-simple-imenu-settings' for details.")
 
 (defun unison-ts-mode--eglot-contact (_interactive)
   "Contact function for eglot to connect to UCM LSP server.
-Starts UCM in headless mode if not already running."
-  (let ((port (or (getenv "UNISON_LSP_PORT") "5757")))
-    (unless (ignore-errors
-              (delete-process
-               (make-network-process
-                :name "unison-lsp-check"
-                :host "127.0.0.1"
-                :service (string-to-number port)
-                :nowait nil)))
-      (start-process "ucm-headless" nil "ucm" "headless")
-      (sleep-for 1))
-    (list "127.0.0.1" (string-to-number port))))
+Starts the inferior UCM if nothing is reachable on the LSP port."
+  (unison-ts--start-ucm-inferior)
+  (list "127.0.0.1" (unison-ts--resolve-lsp-port)))
 
 (defun unison-ts-mode--kill-ucm-lsp (&rest _)
-  "Kill any UCM process listening on the LSP port.
-Called after eglot shuts down to clean up orphaned UCM processes."
-  (let ((port (string-to-number (or (getenv "UNISON_LSP_PORT") "5757"))))
-    (when-let ((output (shell-command-to-string
-                        (format "lsof -t -i :%d 2>/dev/null" port))))
-      (dolist (pid (split-string output "\n" t))
-        (when (string-match-p "^[0-9]+$" pid)
-          (ignore-errors
-            (signal-process (string-to-number pid) 'TERM)))))))
+  "Tear down the Emacs-managed inferior UCM process.
+Called after eglot shuts down."
+  (unison-ts--cleanup-ucm))
 
 (declare-function eglot-shutdown "ext:eglot")
 
@@ -238,17 +226,8 @@ Call this from your init file:
    (make-lsp-client
     :new-connection (lsp-tcp-connection
                      (lambda (_port)
-                       (let ((lsp-port (or (getenv "UNISON_LSP_PORT") "5757")))
-                         (unless (ignore-errors
-                                   (delete-process
-                                    (make-network-process
-                                     :name "unison-lsp-check-lsp-mode"
-                                     :host "127.0.0.1"
-                                     :service (string-to-number lsp-port)
-                                     :nowait nil)))
-                           (start-process "ucm-headless-lsp-mode" nil "ucm" "headless")
-                           (sleep-for 1))
-                         (cons "localhost" (string-to-number lsp-port)))))
+                       (unison-ts--start-ucm-inferior)
+                       (cons "localhost" (unison-ts--resolve-lsp-port))))
     :activation-fn (lsp-activate-on "unison")
     :server-id 'unison-lsp
     :major-modes '(unison-ts-mode)

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -730,10 +730,16 @@ LSP/MCP port never becomes reachable after starting."
       nil)
      (t
       (let* ((default-directory (unison-ts-project-root))
-             (buf (make-comint-in-buffer "ucm" buf-name
-                                         unison-ts-ucm-executable nil)))
+             (buf (get-buffer-create buf-name)))
+        ;; Set the mode BEFORE attaching the process.  `make-comint-in-buffer'
+        ;; sees `derived-mode-p' is t and skips its own `comint-mode' setup,
+        ;; which avoids a race where `kill-all-local-variables' blanks
+        ;; `comint-last-output-start' while UCM is already emitting output —
+        ;; an `:after' advice on `comint-output-filter' (e.g. Doom's
+        ;; `doom--comint-enable-undo-a') would then crash on the nil marker.
         (with-current-buffer buf
           (unison-ts-inferior-ucm-mode))
+        (make-comint-in-buffer "ucm" buf unison-ts-ucm-executable nil)
         (setq unison-ts--ucm-process (get-buffer-process buf))
         (when unison-ts--ucm-process
           (set-process-query-on-exit-flag unison-ts--ucm-process nil))

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -215,9 +215,19 @@ Signals an error if no project context is found."
 
 (defcustom unison-ts-lsp-port 5757
   "Port for the UCM LSP server.
-This is the default port UCM uses for LSP (language server protocol)."
+This is the default port UCM uses for LSP (language server protocol).
+The environment variable UNISON_LSP_PORT overrides this value at
+runtime via `unison-ts--resolve-lsp-port'."
   :type 'integer
   :group 'unison-ts-repl)
+
+(defun unison-ts--resolve-lsp-port ()
+  "Return the effective UCM LSP port.
+Uses the UNISON_LSP_PORT env var when set, falling back to the
+`unison-ts-lsp-port' defcustom."
+  (if-let ((env (getenv "UNISON_LSP_PORT")))
+      (string-to-number env)
+    unison-ts-lsp-port))
 
 (defun unison-ts-api--port-open-p (port)
   "Return non-nil if PORT is accepting connections on localhost."
@@ -233,7 +243,7 @@ This is the default port UCM uses for LSP (language server protocol)."
 
 (defun unison-ts-api--lsp-running-p ()
   "Return non-nil if UCM LSP server is running."
-  (unison-ts-api--port-open-p unison-ts-lsp-port))
+  (unison-ts-api--port-open-p (unison-ts--resolve-lsp-port)))
 
 (defun unison-ts-project-root ()
   "Find Unison project root by looking for .unison directory.
@@ -651,51 +661,120 @@ Returns nil if no REPL buffer exists or it's not usable."
         (when (derived-mode-p 'unison-ts-mcp-repl-mode)
           buf)))))
 
-(defvar unison-ts--ucm-headless-process nil
-  "Process object for UCM headless started by us.")
+;;; Inferior UCM
+;;
+;; The inferior UCM is the full `ucm' executable running inside an Emacs
+;; comint buffer.  It serves both LSP (for eglot/lsp-mode) and MCP (for
+;; the REPL) on `unison-ts-lsp-port'.  Running the full UCM rather than
+;; `ucm headless' means the user can interact with the UCM TUI inside
+;; Emacs without fighting the codebase lock — the lock is held by the
+;; same UCM that Emacs is talking to.
+;;
+;; This addresses gh#8: an Emacs-spawned `ucm headless' previously held
+;; the lock and prevented users from running `ucm' (full TUI) elsewhere.
 
-(defun unison-ts--cleanup-ucm-headless ()
-  "Clean up UCM headless process on Emacs exit."
-  (when (and unison-ts--ucm-headless-process
-             (process-live-p unison-ts--ucm-headless-process))
-    (delete-process unison-ts--ucm-headless-process)
-    (setq unison-ts--ucm-headless-process nil)))
+(defcustom unison-ts-inferior-ucm-buffer-name "*ucm*"
+  "Buffer name for the inferior UCM (full TUI) process."
+  :type 'string
+  :group 'unison-ts-repl)
 
-(add-hook 'kill-emacs-hook #'unison-ts--cleanup-ucm-headless)
+(defvar unison-ts--ucm-process nil
+  "Process object for the inferior UCM started by Emacs.")
 
-(defun unison-ts--start-ucm-headless ()
-  "Start UCM in headless mode if not already running.
-Returns non-nil when UCM headless is ready."
-  (unless (unison-ts-api--lsp-running-p)
-    (let ((default-directory (unison-ts-project-root)))
-      (message "Starting UCM headless...")
-      (setq unison-ts--ucm-headless-process
-            (start-process "ucm-headless" "*ucm-headless*"
-                           unison-ts-ucm-executable "headless"))
-      (set-process-query-on-exit-flag unison-ts--ucm-headless-process nil)
-      ;; Wait for LSP port to be ready (max 10 seconds)
-      (let ((attempts 0))
-        (while (and (< attempts unison-ts--lsp-startup-max-attempts)
-                    (not (unison-ts-api--lsp-running-p)))
-          (sit-for 0.1)
-          (setq attempts (1+ attempts))))
-      (if (unison-ts-api--lsp-running-p)
-          (message "UCM headless started on port %d" unison-ts-lsp-port)
-        (error "Failed to start UCM headless"))))
-  t)
+(defun unison-ts--ucm-on-buffer-kill ()
+  "Buffer-local hook: stop the tracked UCM process without killing the buffer.
+The buffer is being killed already; recursing through `unison-ts--cleanup-ucm'
+would call `kill-buffer' again and blow the stack."
+  (when (and unison-ts--ucm-process
+             (process-live-p unison-ts--ucm-process))
+    (delete-process unison-ts--ucm-process))
+  (setq unison-ts--ucm-process nil))
+
+(defun unison-ts--cleanup-ucm ()
+  "Tear down the inferior UCM process and buffer started by Emacs."
+  (when-let ((buf (get-buffer unison-ts-inferior-ucm-buffer-name)))
+    (let ((kill-buffer-query-functions nil))
+      (kill-buffer buf)))
+  (when (and unison-ts--ucm-process
+             (process-live-p unison-ts--ucm-process))
+    (delete-process unison-ts--ucm-process))
+  (setq unison-ts--ucm-process nil))
+
+(add-hook 'kill-emacs-hook #'unison-ts--cleanup-ucm)
+
+(define-derived-mode unison-ts-inferior-ucm-mode comint-mode "UCM"
+  "Major mode for the inferior UCM (Unison Codebase Manager) process.
+
+Inherits from `comint-mode' and enables ANSI colour processing so
+UCM's coloured output renders correctly."
+  :group 'unison-ts-repl
+  (setq-local comint-prompt-regexp "^[^>\n]*>+ ")
+  (setq-local comint-prompt-read-only t)
+  (setq-local comint-process-echoes nil)
+  (ansi-color-for-comint-mode-on)
+  (add-hook 'kill-buffer-hook #'unison-ts--ucm-on-buffer-kill nil t))
+
+(defun unison-ts--start-ucm-inferior ()
+  "Start the inferior UCM process if not already running.
+Returns the inferior UCM buffer, or nil when an external UCM is
+already serving `unison-ts-lsp-port'.  Signals an error if the
+LSP/MCP port never becomes reachable after starting."
+  (unison-ts--ensure-ucm)
+  (let* ((buf-name unison-ts-inferior-ucm-buffer-name)
+         (existing-buf (get-buffer buf-name))
+         (existing-proc (and existing-buf (get-buffer-process existing-buf))))
+    (cond
+     ((and existing-proc (process-live-p existing-proc))
+      existing-buf)
+     ((unison-ts-api--lsp-running-p)
+      nil)
+     (t
+      (let* ((default-directory (unison-ts-project-root))
+             (buf (make-comint-in-buffer "ucm" buf-name
+                                         unison-ts-ucm-executable nil)))
+        (with-current-buffer buf
+          (unison-ts-inferior-ucm-mode))
+        (setq unison-ts--ucm-process (get-buffer-process buf))
+        (when unison-ts--ucm-process
+          (set-process-query-on-exit-flag unison-ts--ucm-process nil))
+        (message "Starting UCM...")
+        (let ((attempts 0))
+          (while (and (< attempts unison-ts--lsp-startup-max-attempts)
+                      (not (unison-ts-api--lsp-running-p)))
+            (sit-for 0.1)
+            (setq attempts (1+ attempts))))
+        (unless (unison-ts-api--lsp-running-p)
+          (unison-ts--cleanup-ucm)
+          (error "UCM started but LSP/MCP port %d did not open"
+                 (unison-ts--resolve-lsp-port)))
+        (message "UCM started on port %d" (unison-ts--resolve-lsp-port))
+        buf)))))
+
+;;;###autoload
+(defun unison-ts-inferior-ucm ()
+  "Switch to the inferior UCM buffer, starting UCM if needed.
+The inferior UCM is the full `ucm' TUI running inside Emacs; it
+serves both eglot and the MCP REPL.  Errors when an external UCM
+is already holding the codebase lock — manage it there instead."
+  (interactive)
+  (let ((buf (unison-ts--start-ucm-inferior)))
+    (unless buf
+      (user-error
+       "UCM is already running externally on port %d; manage it there"
+       (unison-ts--resolve-lsp-port)))
+    (pop-to-buffer buf)))
 
 (defun unison-ts-repl--start ()
   "Start UCM REPL for the current project.
-Always uses MCP-based REPL. If no UCM headless is running, starts one first.
-This ensures a single UCM process serves both LSP (eglot) and REPL."
+Always uses MCP-based REPL.  If no UCM is running, starts the
+inferior UCM first.  A single UCM process serves both LSP (eglot)
+and the MCP REPL."
   (unison-ts--ensure-ucm)
   (let ((existing-buf (unison-ts-repl--get-buffer)))
     (cond
-     ;; Already have a usable REPL buffer
      (existing-buf existing-buf)
-     ;; Start UCM headless if needed, then use MCP REPL
      (t
-      (unison-ts--start-ucm-headless)
+      (unison-ts--start-ucm-inferior)
       (unison-ts-repl--start-mcp)))))
 
 (defun unison-ts-repl--start-mcp ()

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -730,7 +730,8 @@ LSP/MCP port never becomes reachable after starting."
       nil)
      (t
       (let* ((default-directory (unison-ts-project-root))
-             (buf (get-buffer-create buf-name)))
+             (buf (get-buffer-create buf-name))
+             (port (unison-ts--resolve-lsp-port)))
         ;; Set the mode BEFORE attaching the process.  `make-comint-in-buffer'
         ;; sees `derived-mode-p' is t and skips its own `comint-mode' setup,
         ;; which avoids a race where `kill-all-local-variables' blanks
@@ -741,8 +742,10 @@ LSP/MCP port never becomes reachable after starting."
           (unison-ts-inferior-ucm-mode))
         (make-comint-in-buffer "ucm" buf unison-ts-ucm-executable nil)
         (setq unison-ts--ucm-process (get-buffer-process buf))
-        (when unison-ts--ucm-process
-          (set-process-query-on-exit-flag unison-ts--ucm-process nil))
+        (unless unison-ts--ucm-process
+          (kill-buffer buf)
+          (error "make-comint-in-buffer did not attach a process to %s" buf-name))
+        (set-process-query-on-exit-flag unison-ts--ucm-process nil)
         (message "Starting UCM...")
         (let ((attempts 0))
           (while (and (< attempts unison-ts--lsp-startup-max-attempts)
@@ -751,9 +754,8 @@ LSP/MCP port never becomes reachable after starting."
             (setq attempts (1+ attempts))))
         (unless (unison-ts-api--lsp-running-p)
           (unison-ts--cleanup-ucm)
-          (error "UCM started but LSP/MCP port %d did not open"
-                 (unison-ts--resolve-lsp-port)))
-        (message "UCM started on port %d" (unison-ts--resolve-lsp-port))
+          (error "UCM started but LSP/MCP port %d did not open" port))
+        (message "UCM started on port %d" port)
         buf)))))
 
 ;;;###autoload

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -87,24 +87,24 @@ If CALLBACK is nil, runs synchronously and returns responses."
          (input (mapconcat #'json-encode all-requests "\n")))
     (if callback
         ;; Async mode
-        (let ((output-buffer (generate-new-buffer " *ucm-mcp-output*")))
-          (make-process
-           :name "ucm-mcp"
-           :buffer output-buffer
-           :command (list unison-ts-ucm-executable "mcp")
-           :connection-type 'pipe
-           :sentinel (lambda (proc _event)
-                       (when (memq (process-status proc) '(exit signal))
-                         (let ((responses (unison-ts-mcp--parse-output output-buffer)))
-                           (kill-buffer output-buffer)
-                           (funcall callback responses))))
-           :filter (lambda (proc string)
-                     (with-current-buffer (process-buffer proc)
-                       (goto-char (point-max))
-                       (insert string))))
-          (process-send-string "ucm-mcp" input)
-          (process-send-string "ucm-mcp" "\n")
-          (process-send-eof "ucm-mcp")
+        (let* ((output-buffer (generate-new-buffer " *ucm-mcp-output*"))
+               (proc (make-process
+                      :name "ucm-mcp"
+                      :buffer output-buffer
+                      :command (list unison-ts-ucm-executable "mcp")
+                      :connection-type 'pipe
+                      :sentinel (lambda (proc _event)
+                                  (when (memq (process-status proc) '(exit signal))
+                                    (let ((responses (unison-ts-mcp--parse-output output-buffer)))
+                                      (kill-buffer output-buffer)
+                                      (funcall callback responses))))
+                      :filter (lambda (proc string)
+                                (with-current-buffer (process-buffer proc)
+                                  (goto-char (point-max))
+                                  (insert string))))))
+          (process-send-string proc input)
+          (process-send-string proc "\n")
+          (process-send-eof proc)
           nil)
       ;; Sync mode (for REPL)
       (let ((output (with-temp-buffer

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -246,11 +246,9 @@ Uses the UNISON_LSP_PORT env var when set, falling back to the
   (unison-ts-api--port-open-p (unison-ts--resolve-lsp-port)))
 
 (defun unison-ts-project-root ()
-  "Find Unison project root by looking for .unison directory.
-Falls back to `project-root' or `default-directory'."
-  (or (locate-dominating-file default-directory ".unison")
-      (when-let ((proj (project-current)))
-        (project-root proj))
+  "Find the project root for the current buffer.
+Prefers `project-current'; falls back to `default-directory'."
+  (or (when-let ((proj (project-current))) (project-root proj))
       default-directory))
 
 (defun unison-ts-project-name ()


### PR DESCRIPTION
closes #13

the `locate-dominating-file ... ".unison"` walk always terminates at `~` because UCM keeps a single global codebase at `~/.unison/`. this meant `project-current` never ran and the returned root was `~` for any buffer outside home.

drop the dominating-file lookup entirely and go straight to `project-current`, falling back to `default-directory`.

regression test: `unison-ts-repl/project-root-prefers-project-current`