### PR TITLE
fix(repl): pass process object to MCP send-string (gh#11)

### DIFF
--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1350,6 +1350,31 @@
   (require 'unison-ts-repl)
   (should (fboundp 'unison-ts-mcp--run)))
 
+(ert-deftest unison-ts-mcp/async-uses-process-object-not-name ()
+  "`unison-ts-mcp--call' must send to the process object returned
+by `make-process', not look it up by the name string \"ucm-mcp\".
+
+Looking up by name hits a stale finished process when emacs has
+auto-uniquified the new process to `ucm-mcp<2>'.  Capturing the
+object is the regression-proof fix (gh#11)."
+  (require 'unison-ts-repl)
+  (require 'cl-lib)
+  (let ((fake-proc (start-process "test-mcp-fake" nil "true"))
+        (send-targets nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'make-process)
+                   (lambda (&rest _) fake-proc))
+                  ((symbol-function 'process-send-string)
+                   (lambda (target _string) (push target send-targets)))
+                  ((symbol-function 'process-send-eof)
+                   (lambda (target) (push target send-targets))))
+          (unison-ts-mcp--call '(("noop" . nil)) (lambda (_r) nil)))
+      (when (process-live-p fake-proc) (delete-process fake-proc)))
+    (should send-targets)
+    (dolist (target send-targets)
+      (should (eq target fake-proc))
+      (should-not (stringp target)))))
+
 ;;; Inferior UCM (gh#8) — full UCM in a comint buffer, no separate `ucm headless'
 
 (ert-deftest unison-ts-inferior/mode-defined ()

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -87,24 +87,24 @@ If CALLBACK is nil, runs synchronously and returns responses."
          (input (mapconcat #'json-encode all-requests "\n")))
     (if callback
         ;; Async mode
-        (let ((output-buffer (generate-new-buffer " *ucm-mcp-output*")))
-          (make-process
-           :name "ucm-mcp"
-           :buffer output-buffer
-           :command (list unison-ts-ucm-executable "mcp")
-           :connection-type 'pipe
-           :sentinel (lambda (proc _event)
-                       (when (memq (process-status proc) '(exit signal))
-                         (let ((responses (unison-ts-mcp--parse-output output-buffer)))
-                           (kill-buffer output-buffer)
-                           (funcall callback responses))))
-           :filter (lambda (proc string)
-                     (with-current-buffer (process-buffer proc)
-                       (goto-char (point-max))
-                       (insert string))))
-          (process-send-string "ucm-mcp" input)
-          (process-send-string "ucm-mcp" "\n")
-          (process-send-eof "ucm-mcp")
+        (let* ((output-buffer (generate-new-buffer " *ucm-mcp-output*"))
+               (proc (make-process
+                      :name "ucm-mcp"
+                      :buffer output-buffer
+                      :command (list unison-ts-ucm-executable "mcp")
+                      :connection-type 'pipe
+                      :sentinel (lambda (proc _event)
+                                  (when (memq (process-status proc) '(exit signal))
+                                    (let ((responses (unison-ts-mcp--parse-output output-buffer)))
+                                      (kill-buffer output-buffer)
+                                      (funcall callback responses))))
+                      :filter (lambda (proc string)
+                                (with-current-buffer (process-buffer proc)
+                                  (goto-char (point-max))
+                                  (insert string))))))
+          (process-send-string proc input)
+          (process-send-string proc "\n")
+          (process-send-eof proc)
           nil)
       ;; Sync mode (for REPL)
       (let ((output (with-temp-buffer


### PR DESCRIPTION
fixes #11. supersedes #12 (auto-closed when its stacked base branch was deleted on #10 merge).

`unison-ts-mcp--call` async branch was looking up the process by name string `"ucm-mcp"` after `make-process`, instead of using the returned object. on a stale-name collision (previous `ucm-mcp` still in the process list as `finished`) emacs auto-uniquifies the new name to `ucm-mcp<2>` and the sends hit the dead one.

bind the result of `make-process` to `proc` and pass it directly to `process-send-string` / `process-send-eof`.

regression test: `unison-ts-mcp/async-uses-process-object-not-name` (asserts targets equal the process object, not the string).