### PR TITLE
fix(repl): use project-current for project root (gh#13)

### DIFF
--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1265,16 +1265,34 @@
 ;;; REPL integration tests
 
 (ert-deftest unison-ts-repl/project-root-fallback ()
-  "Project root should fall back to default-directory."
+  "Project root falls back to `default-directory' when no project."
   (require 'unison-ts-repl)
-  (let ((default-directory "/tmp/"))
-    (should (equal (unison-ts-project-root) "/tmp/"))))
+  (require 'cl-lib)
+  (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
+    (let ((default-directory "/tmp/"))
+      (should (equal (unison-ts-project-root) "/tmp/")))))
+
+(ert-deftest unison-ts-repl/project-root-prefers-project-current ()
+  "Project root uses `project-current' when available (gh#13).
+Walking up to find `.unison' is wrong: UCM stores its global codebase
+at `~/.unison/' so the walk always terminates at home."
+  (require 'unison-ts-repl)
+  (require 'cl-lib)
+  (let ((fake-proj (cons 'fake-project "/some/proj-root/")))
+    (cl-letf (((symbol-function 'project-current)
+               (lambda (&rest _) fake-proj))
+              ((symbol-function 'project-root)
+               (lambda (proj) (cdr proj))))
+      (let ((default-directory "/some/proj-root/sub/"))
+        (should (equal (unison-ts-project-root) "/some/proj-root/"))))))
 
 (ert-deftest unison-ts-repl/project-name ()
-  "Project name should be directory name."
+  "Project name is the trailing directory of the project root."
   (require 'unison-ts-repl)
-  (let ((default-directory "/tmp/my-project/"))
-    (should (equal (unison-ts-project-name) "my-project"))))
+  (require 'cl-lib)
+  (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
+    (let ((default-directory "/tmp/my-project/"))
+      (should (equal (unison-ts-project-name) "my-project")))))
 
 (ert-deftest unison-ts-repl/buffer-name-format ()
   "REPL buffer name should include project name."

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -246,10 +246,9 @@ Uses the UNISON_LSP_PORT env var when set, falling back to the
   (unison-ts-api--port-open-p (unison-ts--resolve-lsp-port)))
 
 (defun unison-ts-project-root ()
-  "Find Unison project root by looking for .unison directory.
-Falls back to `project-root' or `default-directory'."
-  (or (locate-dominating-file default-directory ".unison")
-      (when-let ((proj (project-current)))
+  "Find the project root for the current buffer.
+Prefers `project-current'; falls back to `default-directory'."
+  (or (when-let ((proj (project-current)))
         (project-root proj))
       default-directory))
 


### PR DESCRIPTION
fixes #13. supersedes #14 (auto-closed when its stacked base branch was deleted on #17 merge).

`unison-ts-project-root` walked up looking for a `.unison` directory. UCM stores its single global codebase at `~/.unison/`, so the walk always terminated at home for any buffer outside `~`, and the `project-current` fallback never ran. REPL buffers showed up as `Project: ~` / `*ucm: ~*` instead of the actual project name.

drop the dominating-file lookup. prefer `project-current`, fall back to `default-directory`.

tests: `unison-ts-repl/project-root-fallback` updated to stub `project-current`. new `unison-ts-repl/project-root-prefers-project-current` covers the primary path.