### PR TITLE
feat(repl): add -and-go variants for eval/send commands (gh#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ Interact with UCM directly from Emacs. Open the REPL with `C-c C-u r` or use the
 | `C-c C-u x` | `unison-ts-run` | Run a term |
 | `C-c C-u w` | `unison-ts-watch` | Watch current file for changes |
 | `C-c C-u l` | `unison-ts-load` | Load current file |
+| `C-c C-u v` | `unison-ts-eval` | Evaluate expression via MCP |
+| `C-c C-u e` | `unison-ts-send-region` | Send region to UCM via MCP |
+| `C-c C-u d` | `unison-ts-send-definition` | Send definition at point to UCM |
+| `C-c C-u V` | `unison-ts-eval-and-go` | Evaluate expression and switch to REPL |
+| `C-c C-u E` | `unison-ts-send-region-and-go` | Send region to REPL and switch to it |
+| `C-c C-u D` | `unison-ts-send-definition-and-go` | Send definition to REPL and switch to it |
 
 ## Troubleshooting
 

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1553,32 +1553,28 @@ on `comint-output-filter' that reads the marker (e.g. Doom's
               'unison-ts-send-definition-and-go)))
 
 (ert-deftest unison-ts-and-go/eval-routes-to-watch ()
-  "`unison-ts-eval-and-go' must call `unison-ts-mcp-repl--execute-async'
-with command 'watch and the expression as args."
+  "`unison-ts-eval-and-go' synthesises a \"> expr\" command that the parser
+routes to the 'watch command."
   (require 'unison-ts-repl)
-  (require 'cl-lib)
-  (let ((captured-command nil)
-        (captured-args nil)
-        (repl-buf (get-buffer-create "*ucm-test-and-go*")))
-    (unwind-protect
-        (progn
-          (with-current-buffer repl-buf
-            (unison-ts-mcp-repl-mode)
-            (setq unison-ts-mcp-repl--project-root default-directory)
-            (unison-ts-mcp-repl--insert-prompt))
-          ;; Stub the REPL buffer lookup so we get our test buffer.
-          (cl-letf (((symbol-function 'unison-ts-repl--get-buffer)
-                     (lambda () repl-buf))
-                    ((symbol-function 'pop-to-buffer)
-                     (lambda (_buf) nil))
-                    ((symbol-function 'unison-ts-mcp-repl--execute-async)
-                     (lambda (cmd args _cb)
-                       (setq captured-command cmd)
-                       (setq captured-args args))))
-            (unison-ts-eval-and-go "1 + 2"))
-          (should (eq captured-command 'watch))
-          (should (equal captured-args "1 + 2")))
-      (when (buffer-live-p repl-buf) (kill-buffer repl-buf)))))
+  (let ((parsed (unison-ts-mcp-repl--parse-command "> 1 + 2")))
+    (should (eq (car parsed) 'watch))
+    (should (equal (cdr parsed) "1 + 2"))))
+
+(ert-deftest unison-ts-and-go/send-region-routes-to-add ()
+  "`unison-ts-send-region-and-go' synthesises an \"add <code>\" command that
+the parser routes to the 'add command."
+  (require 'unison-ts-repl)
+  (let ((parsed (unison-ts-mcp-repl--parse-command "add foo x = x + 1")))
+    (should (eq (car parsed) 'add))
+    (should (equal (cdr parsed) "foo x = x + 1"))))
+
+(ert-deftest unison-ts-and-go/multiline-add-parses-cleanly ()
+  "Multi-line add input must not be truncated at the first newline."
+  (require 'unison-ts-repl)
+  (let* ((input "add foo = 1\nbar = 2")
+         (parsed (unison-ts-mcp-repl--parse-command input)))
+    (should (eq (car parsed) 'add))
+    (should (equal (cdr parsed) "foo = 1\nbar = 2"))))
 
 (provide 'unison-ts-mode-tests)
 ;;; unison-ts-mode-tests.el ends here

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1530,5 +1530,55 @@ on `comint-output-filter' that reads the marker (e.g. Doom's
     (should (null unison-ts--ucm-process))
     (should-not (get-buffer unison-ts-inferior-ucm-buffer-name))))
 
+;;; -and-go command tests (gh#15)
+
+(ert-deftest unison-ts-and-go/commands-are-interactive ()
+  "All -and-go commands must be autoloaded interactive commands."
+  (require 'unison-ts-repl)
+  (should (fboundp 'unison-ts-eval-and-go))
+  (should (commandp 'unison-ts-eval-and-go))
+  (should (fboundp 'unison-ts-send-region-and-go))
+  (should (commandp 'unison-ts-send-region-and-go))
+  (should (fboundp 'unison-ts-send-definition-and-go))
+  (should (commandp 'unison-ts-send-definition-and-go)))
+
+(ert-deftest unison-ts-and-go/keybindings ()
+  "Uppercase V/E/D must be bound to the -and-go variants."
+  (require 'unison-ts-mode)
+  (should (eq (lookup-key unison-ts-mode-map (kbd "C-c C-u V"))
+              'unison-ts-eval-and-go))
+  (should (eq (lookup-key unison-ts-mode-map (kbd "C-c C-u E"))
+              'unison-ts-send-region-and-go))
+  (should (eq (lookup-key unison-ts-mode-map (kbd "C-c C-u D"))
+              'unison-ts-send-definition-and-go)))
+
+(ert-deftest unison-ts-and-go/eval-routes-to-watch ()
+  "`unison-ts-eval-and-go' must call `unison-ts-mcp-repl--execute-async'
+with command 'watch and the expression as args."
+  (require 'unison-ts-repl)
+  (require 'cl-lib)
+  (let ((captured-command nil)
+        (captured-args nil)
+        (repl-buf (get-buffer-create "*ucm-test-and-go*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer repl-buf
+            (unison-ts-mcp-repl-mode)
+            (setq unison-ts-mcp-repl--project-root default-directory)
+            (unison-ts-mcp-repl--insert-prompt))
+          ;; Stub the REPL buffer lookup so we get our test buffer.
+          (cl-letf (((symbol-function 'unison-ts-repl--get-buffer)
+                     (lambda () repl-buf))
+                    ((symbol-function 'pop-to-buffer)
+                     (lambda (_buf) nil))
+                    ((symbol-function 'unison-ts-mcp-repl--execute-async)
+                     (lambda (cmd args _cb)
+                       (setq captured-command cmd)
+                       (setq captured-args args))))
+            (unison-ts-eval-and-go "1 + 2"))
+          (should (eq captured-command 'watch))
+          (should (equal captured-args "1 + 2")))
+      (when (buffer-live-p repl-buf) (kill-buffer repl-buf)))))
+
 (provide 'unison-ts-mode-tests)
 ;;; unison-ts-mode-tests.el ends here

--- a/unison-ts-mode.el
+++ b/unison-ts-mode.el
@@ -54,6 +54,9 @@
 ;;   C-c C-u l - Load current file
 ;;   C-c C-u e - Send region to REPL
 ;;   C-c C-u d - Send definition at point to REPL
+;;   C-c C-u V - Eval expression and go to REPL
+;;   C-c C-u E - Send region to REPL and go
+;;   C-c C-u D - Send definition to REPL and go
 ;;
 ;; Forked from https://github.com/dariooddenino/unison-ts-mode-emacs.
 
@@ -137,6 +140,9 @@ See `treesit-simple-imenu-settings' for details.")
     (define-key map (kbd "C-c C-u l") #'unison-ts-load)
     (define-key map (kbd "C-c C-u e") #'unison-ts-send-region)
     (define-key map (kbd "C-c C-u d") #'unison-ts-send-definition)
+    (define-key map (kbd "C-c C-u V") #'unison-ts-eval-and-go)
+    (define-key map (kbd "C-c C-u E") #'unison-ts-send-region-and-go)
+    (define-key map (kbd "C-c C-u D") #'unison-ts-send-definition-and-go)
     map)
   "Keymap for `unison-ts-mode'.")
 

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -480,27 +480,27 @@ Examples:
      ((string-match-p "^help\\s-*$" trimmed)
       (cons 'help nil))
      ;; Watch/evaluate: starts with >
-     ((string-match "^>\\s-*\\(.*\\)" trimmed)
+     ((string-match "^>\\s-*\\(\\(?:.\\|\n\\)*\\)" trimmed)
       (cons 'watch (match-string 1 trimmed)))
-     ;; Add definitions
-     ((string-match "^add\\s-+\\(.*\\)" trimmed)
+     ;; Add definitions (may span multiple lines)
+     ((string-match "^add\\s-+\\(\\(?:.\\|\n\\)*\\)" trimmed)
       (cons 'add (match-string 1 trimmed)))
      ;; Test
-     ((string-match "^test\\(?:\\s-+\\(.*\\)\\)?$" trimmed)
+     ((string-match "^test\\(?:\\s-+\\(\\(?:.\\|\n\\)*\\)\\)?$" trimmed)
       (cons 'test (match-string 1 trimmed)))
      ;; Run
-     ((string-match "^run\\s-+\\(\\S-+\\)\\(?:\\s-+\\(.*\\)\\)?$" trimmed)
+     ((string-match "^run\\s-+\\(\\S-+\\)\\(?:\\s-+\\(\\(?:.\\|\n\\)*\\)\\)?$" trimmed)
       (cons 'run (cons (match-string 1 trimmed)
                        (when (match-string 2 trimmed)
                          (split-string (match-string 2 trimmed))))))
      ;; View
-     ((string-match "^view\\s-+\\(.*\\)" trimmed)
+     ((string-match "^view\\s-+\\(\\(?:.\\|\n\\)*\\)" trimmed)
       (cons 'view (split-string (match-string 1 trimmed))))
      ;; Find by type (find : <type>)
-     ((string-match "^find\\s-*:\\s-*\\(.*\\)" trimmed)
+     ((string-match "^find\\s-*:\\s-*\\(\\(?:.\\|\n\\)*\\)" trimmed)
       (cons 'find-type (match-string 1 trimmed)))
      ;; Find by name
-     ((string-match "^find\\s-+\\(.*\\)" trimmed)
+     ((string-match "^find\\s-+\\(\\(?:.\\|\n\\)*\\)" trimmed)
       (cons 'find-name (match-string 1 trimmed)))
      ;; Docs
      ((string-match "^docs\\s-+\\(\\S-+\\)" trimmed)
@@ -846,38 +846,30 @@ PROC is the process.  Auto-close buffer on success after
                             (delete-windows-on buf)
                             (kill-buffer buf))))))))
 
-(defun unison-ts--send-to-repl (command)
+(defun unison-ts--send-to-repl--impl (command select)
   "Send COMMAND to the UCM REPL, starting it if needed.
-Works with both subprocess-based and MCP-based REPLs."
+If SELECT is non-nil, use `pop-to-buffer' to switch to the REPL;
+otherwise use `display-buffer'."
+  (unison-ts--ensure-ucm)
   (let ((buf (or (unison-ts-repl--get-buffer)
                  (unison-ts-repl--start))))
     (with-current-buffer buf
       (if (derived-mode-p 'unison-ts-mcp-repl-mode)
-          ;; MCP REPL - insert command and send
           (progn
             (goto-char (point-max))
             (insert command)
             (unison-ts-mcp-repl-send))
-        ;; Comint REPL - send to process
         (goto-char (point-max))
         (comint-send-string (get-buffer-process buf) (concat command "\n"))))
-    (display-buffer buf)))
+    (funcall (if select #'pop-to-buffer #'display-buffer) buf)))
+
+(defun unison-ts--send-to-repl (command)
+  "Send COMMAND to the UCM REPL, starting it if needed."
+  (unison-ts--send-to-repl--impl command nil))
 
 (defun unison-ts--send-to-repl-and-go (command)
-  "Send COMMAND to the UCM REPL and switch to it.
-Like `unison-ts--send-to-repl' but uses `pop-to-buffer' instead of
-`display-buffer' so the REPL becomes the selected window."
-  (let ((buf (or (unison-ts-repl--get-buffer)
-                 (unison-ts-repl--start))))
-    (with-current-buffer buf
-      (if (derived-mode-p 'unison-ts-mcp-repl-mode)
-          (progn
-            (goto-char (point-max))
-            (insert command)
-            (unison-ts-mcp-repl-send))
-        (goto-char (point-max))
-        (comint-send-string (get-buffer-process buf) (concat command "\n"))))
-    (pop-to-buffer buf)))
+  "Send COMMAND to the UCM REPL and switch to it."
+  (unison-ts--send-to-repl--impl command t))
 
 (defun unison-ts--parse-mcp-output (text)
   "Parse MCP output TEXT which may be JSON-encoded UCM response."
@@ -1080,19 +1072,24 @@ For pure expressions, use `unison-ts-eval' instead."
   (member (treesit-node-type node)
           '("term_declaration" "type_declaration" "ability_declaration")))
 
-;;;###autoload
-(defun unison-ts-send-definition ()
-  "Send the definition at point to UCM via MCP."
-  (interactive)
+(defun unison-ts--definition-at-point ()
+  "Return the source text of the definition at point.
+Signals `user-error' if point is not on a definition node."
   (let ((node (treesit-node-at (point))))
     (unless node
       (user-error "No tree-sitter node at point"))
     (let ((def-node (treesit-parent-until node #'unison-ts--definition-node-p t)))
       (unless def-node
         (user-error "Point is not within a definition"))
-      (let* ((code (treesit-node-text def-node t))
-             (result (unison-ts-mcp--update-definitions code)))
-        (unison-ts--display-mcp-result result "eval")))))
+      (treesit-node-text def-node t))))
+
+;;;###autoload
+(defun unison-ts-send-definition ()
+  "Send the definition at point to UCM via MCP."
+  (interactive)
+  (let* ((code (unison-ts--definition-at-point))
+         (result (unison-ts-mcp--update-definitions code)))
+    (unison-ts--display-mcp-result result "eval")))
 
 ;;;###autoload
 (defun unison-ts-eval-and-go (expr)
@@ -1120,14 +1117,7 @@ REPL buffer, mirroring `unison-ts-send-region'."
 Inserts \"add <definition>\" as a typed-prompt entry and switches to
 the REPL buffer, mirroring `unison-ts-send-definition'."
   (interactive)
-  (let ((node (treesit-node-at (point))))
-    (unless node
-      (user-error "No tree-sitter node at point"))
-    (let ((def-node (treesit-parent-until node #'unison-ts--definition-node-p t)))
-      (unless def-node
-        (user-error "Point is not within a definition"))
-      (let ((code (treesit-node-text def-node t)))
-        (unison-ts--send-to-repl-and-go (concat "add " code))))))
+  (unison-ts--send-to-repl-and-go (concat "add " (unison-ts--definition-at-point))))
 
 (provide 'unison-ts-repl)
 

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -863,6 +863,22 @@ Works with both subprocess-based and MCP-based REPLs."
         (comint-send-string (get-buffer-process buf) (concat command "\n"))))
     (display-buffer buf)))
 
+(defun unison-ts--send-to-repl-and-go (command)
+  "Send COMMAND to the UCM REPL and switch to it.
+Like `unison-ts--send-to-repl' but uses `pop-to-buffer' instead of
+`display-buffer' so the REPL becomes the selected window."
+  (let ((buf (or (unison-ts-repl--get-buffer)
+                 (unison-ts-repl--start))))
+    (with-current-buffer buf
+      (if (derived-mode-p 'unison-ts-mcp-repl-mode)
+          (progn
+            (goto-char (point-max))
+            (insert command)
+            (unison-ts-mcp-repl-send))
+        (goto-char (point-max))
+        (comint-send-string (get-buffer-process buf) (concat command "\n"))))
+    (pop-to-buffer buf)))
+
 (defun unison-ts--parse-mcp-output (text)
   "Parse MCP output TEXT which may be JSON-encoded UCM response."
   (condition-case nil
@@ -1077,6 +1093,41 @@ For pure expressions, use `unison-ts-eval' instead."
       (let* ((code (treesit-node-text def-node t))
              (result (unison-ts-mcp--update-definitions code)))
         (unison-ts--display-mcp-result result "eval")))))
+
+;;;###autoload
+(defun unison-ts-eval-and-go (expr)
+  "Evaluate EXPR via the UCM MCP REPL and switch to the REPL buffer.
+Inserts \"> EXPR\" as a typed-prompt entry and switches to the REPL,
+mirroring `unison-ts-eval' but routing output through the REPL buffer
+instead of the minibuffer or a separate output buffer."
+  (interactive "sExpression: ")
+  (unison-ts--send-to-repl-and-go (concat "> " expr)))
+
+;;;###autoload
+(defun unison-ts-send-region-and-go (start end)
+  "Send the region between START and END to the UCM MCP REPL and switch to it.
+Inserts \"add <region>\" as a typed-prompt entry and switches to the
+REPL buffer, mirroring `unison-ts-send-region'."
+  (interactive "r")
+  (unless (use-region-p)
+    (user-error "No region active"))
+  (let ((code (buffer-substring-no-properties start end)))
+    (unison-ts--send-to-repl-and-go (concat "add " code))))
+
+;;;###autoload
+(defun unison-ts-send-definition-and-go ()
+  "Send the definition at point to the UCM MCP REPL and switch to it.
+Inserts \"add <definition>\" as a typed-prompt entry and switches to
+the REPL buffer, mirroring `unison-ts-send-definition'."
+  (interactive)
+  (let ((node (treesit-node-at (point))))
+    (unless node
+      (user-error "No tree-sitter node at point"))
+    (let ((def-node (treesit-parent-until node #'unison-ts--definition-node-p t)))
+      (unless def-node
+        (user-error "Point is not within a definition"))
+      (let ((code (treesit-node-text def-node t)))
+        (unison-ts--send-to-repl-and-go (concat "add " code))))))
 
 (provide 'unison-ts-repl)
 


### PR DESCRIPTION
closes #15

adds three new interactive commands that route input through the MCP REPL buffer and switch focus to it:

- `unison-ts-eval-and-go` — inserts `> <expr>` into REPL, bound to `C-c C-u V`
- `unison-ts-send-region-and-go` — inserts `add <region>` into REPL, bound to `C-c C-u E`
- `unison-ts-send-definition-and-go` — inserts `add <definition>` into REPL, bound to `C-c C-u D`

built on a new internal helper `unison-ts--send-to-repl-and-go` (like `unison-ts--send-to-repl` but calls `pop-to-buffer` instead of `display-buffer`).

3 new tests added; full suite 181/181 pass.