### PR TITLE
feat(repl): inline result overlay for one-shot eval (gh#16)

### DIFF
--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1530,5 +1530,101 @@ on `comint-output-filter' that reads the marker (e.g. Doom's
     (should (null unison-ts--ucm-process))
     (should-not (get-buffer unison-ts-inferior-ucm-buffer-name))))
 
+;;; Inline eval overlay (gh#16)
+
+(ert-deftest unison-ts-overlay/defcustom-exists ()
+  "unison-ts-eval-overlay defcustom must exist, default to t, and be boolean."
+  (require 'unison-ts-repl)
+  (should (boundp 'unison-ts-eval-overlay))
+  (should (eq unison-ts-eval-overlay t))
+  (should (eq (get 'unison-ts-eval-overlay 'custom-type) 'boolean)))
+
+(ert-deftest unison-ts-overlay/format-defcustom-exists ()
+  "unison-ts-eval-overlay-format defcustom must exist and be a string."
+  (require 'unison-ts-repl)
+  (should (boundp 'unison-ts-eval-overlay-format))
+  (should (stringp unison-ts-eval-overlay-format))
+  (should (string-match-p "%s" unison-ts-eval-overlay-format)))
+
+(ert-deftest unison-ts-overlay/show-creates-overlay ()
+  "unison-ts--overlay-show must create an overlay with the formatted after-string."
+  (require 'unison-ts-repl)
+  (with-temp-buffer
+    (insert "hello")
+    (let ((unison-ts-eval-overlay t)
+          (unison-ts-eval-overlay-format " => %s"))
+      (unison-ts--overlay-show 5 "42")
+      (let ((overlays (overlays-in 5 5)))
+        (should (= (length overlays) 1))
+        (should (string-match-p "42" (overlay-get (car overlays) 'after-string)))))))
+
+(ert-deftest unison-ts-overlay/show-respects-format ()
+  "after-string must use unison-ts-eval-overlay-format."
+  (require 'unison-ts-repl)
+  (with-temp-buffer
+    (insert "hello")
+    (let ((unison-ts-eval-overlay t)
+          (unison-ts-eval-overlay-format ":: %s"))
+      (unison-ts--overlay-show 5 "Nat")
+      (let ((overlays (overlays-in 5 5)))
+        (should (= (length overlays) 1))
+        (should (equal (overlay-get (car overlays) 'after-string)
+                       (propertize ":: Nat" 'face 'unison-ts-eval-overlay-face)))))))
+
+(ert-deftest unison-ts-overlay/pre-command-clears-overlay ()
+  "pre-command-hook must delete the overlay and remove itself."
+  (require 'unison-ts-repl)
+  (with-temp-buffer
+    (insert "hello")
+    (let ((unison-ts-eval-overlay t)
+          (unison-ts-eval-overlay-format " => %s"))
+      (unison-ts--overlay-show 5 "99")
+      (should (overlays-in 5 5))
+      ;; Simulate a pre-command event by running the hook manually.
+      (run-hooks 'pre-command-hook)
+      (should-not (overlays-in 5 5))
+      (should-not (memq #'unison-ts--overlay-clear
+                        (buffer-local-value 'pre-command-hook (current-buffer)))))))
+
+(ert-deftest unison-ts-overlay/disabled-is-noop ()
+  "When unison-ts-eval-overlay is nil, unison-ts--overlay-show must not create an overlay."
+  (require 'unison-ts-repl)
+  (with-temp-buffer
+    (insert "hello")
+    (let ((unison-ts-eval-overlay nil))
+      (unison-ts--overlay-show 5 "42")
+      (should-not (overlays-in 5 5)))))
+
+(ert-deftest unison-ts-overlay/display-mcp-result-success-calls-overlay ()
+  "Success path of unison-ts--display-mcp-result must invoke overlay show."
+  (require 'unison-ts-repl)
+  (require 'cl-lib)
+  (with-temp-buffer
+    (insert "hello world")
+    (let ((unison-ts-eval-overlay t)
+          (unison-ts-eval-overlay-format " => %s")
+          ;; Build a minimal success result identical to what MCP returns.
+          (result `((content . [((type . "text")
+                                 (text . "{\"errorMessages\":[],\"outputMessages\":[\"42\"]}"))]))))
+      (unison-ts--display-mcp-result result "eval" 5)
+      (let ((overlays (overlays-in 5 5)))
+        (should (= (length overlays) 1))
+        (should (string-match-p "42" (overlay-get (car overlays) 'after-string)))))))
+
+(ert-deftest unison-ts-overlay/display-mcp-result-error-no-overlay ()
+  "Error path of unison-ts--display-mcp-result must NOT create an overlay."
+  (require 'unison-ts-repl)
+  (require 'cl-lib)
+  (with-temp-buffer
+    (insert "hello world")
+    (let ((unison-ts-eval-overlay t)
+          (unison-ts-eval-overlay-format " => %s")
+          (result `((content . [((type . "text")
+                                 (text . "{\"errorMessages\":[\"type error\"],\"outputMessages\":[]}"))]))))
+      (cl-letf (((symbol-function 'pop-to-buffer) (lambda (&rest _) nil))
+                ((symbol-function 'display-buffer) (lambda (&rest _) nil)))
+        (unison-ts--display-mcp-result result "eval" 5))
+      (should-not (overlays-in 5 5)))))
+
 (provide 'unison-ts-mode-tests)
 ;;; unison-ts-mode-tests.el ends here

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1532,20 +1532,6 @@ on `comint-output-filter' that reads the marker (e.g. Doom's
 
 ;;; Inline eval overlay (gh#16)
 
-(ert-deftest unison-ts-overlay/defcustom-exists ()
-  "unison-ts-eval-overlay defcustom must exist, default to t, and be boolean."
-  (require 'unison-ts-repl)
-  (should (boundp 'unison-ts-eval-overlay))
-  (should (eq unison-ts-eval-overlay t))
-  (should (eq (get 'unison-ts-eval-overlay 'custom-type) 'boolean)))
-
-(ert-deftest unison-ts-overlay/format-defcustom-exists ()
-  "unison-ts-eval-overlay-format defcustom must exist and be a string."
-  (require 'unison-ts-repl)
-  (should (boundp 'unison-ts-eval-overlay-format))
-  (should (stringp unison-ts-eval-overlay-format))
-  (should (string-match-p "%s" unison-ts-eval-overlay-format)))
-
 (ert-deftest unison-ts-overlay/show-creates-overlay ()
   "unison-ts--overlay-show must create an overlay with the formatted after-string."
   (require 'unison-ts-repl)
@@ -1625,6 +1611,43 @@ on `comint-output-filter' that reads the marker (e.g. Doom's
                 ((symbol-function 'display-buffer) (lambda (&rest _) nil)))
         (unison-ts--display-mcp-result result "eval" 5))
       (should-not (overlays-in 5 5)))))
+
+(ert-deftest unison-ts-overlay/percent-in-result-no-format-error ()
+  "Result strings containing % and %s must not crash and must display literally."
+  (require 'unison-ts-repl)
+  (with-temp-buffer
+    (insert "square = x -> x * x\n")
+    (let ((unison-ts-eval-overlay t)
+          (unison-ts-eval-overlay-format " => %s"))
+      ;; Must not raise a format error for % or %s in result-string.
+      (unison-ts--overlay-show 1 "9 : Nat (100% confidence, %s type)")
+      (let* ((overlays (overlays-in 1 1))
+             (overlay (car overlays))
+             (text (overlay-get overlay 'after-string)))
+        (should (= (length overlays) 1))
+        (should (equal (substring-no-properties text)
+                       " => 9 : Nat (100% confidence, %s type)"))))))
+
+
+(ert-deftest unison-ts-overlay/long-result-skips-overlay ()
+  "Results longer than unison-ts--overlay-max-length must not create an overlay."
+  (require 'unison-ts-repl)
+  (with-temp-buffer
+    (insert "x\n")
+    (let ((unison-ts-eval-overlay t)
+          (unison-ts-eval-overlay-format " => %s"))
+      (unison-ts--overlay-show 1 (make-string (1+ unison-ts--overlay-max-length) ?a))
+      (should-not (overlays-in 1 1)))))
+
+(ert-deftest unison-ts-overlay/multiline-result-skips-overlay ()
+  "Multi-line results must not create an overlay."
+  (require 'unison-ts-repl)
+  (with-temp-buffer
+    (insert "x\n")
+    (let ((unison-ts-eval-overlay t)
+          (unison-ts-eval-overlay-format " => %s"))
+      (unison-ts--overlay-show 1 "line one\nline two")
+      (should-not (overlays-in 1 1)))))
 
 (provide 'unison-ts-mode-tests)
 ;;; unison-ts-mode-tests.el ends here

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -75,11 +75,18 @@ default (minibuffer only)."
   (setq unison-ts--eval-overlay nil)
   (remove-hook 'pre-command-hook #'unison-ts--overlay-clear t))
 
+(defconst unison-ts--overlay-max-length 120
+  "Maximum character length for inline eval result overlays.
+Results longer than this are not shown as overlays.")
+
 (defun unison-ts--overlay-show (position result-string)
   "Display RESULT-STRING as a transient overlay at POSITION.
 POSITION is a buffer position (integer or marker).
-Does nothing when `unison-ts-eval-overlay' is nil."
-  (when unison-ts-eval-overlay
+Does nothing when `unison-ts-eval-overlay' is nil, when RESULT-STRING
+contains a newline, or when it exceeds `unison-ts--overlay-max-length'."
+  (when (and unison-ts-eval-overlay
+             (not (string-match-p "\n" result-string))
+             (<= (length result-string) unison-ts--overlay-max-length))
     (unison-ts--overlay-clear)
     (let* ((text (format unison-ts-eval-overlay-format result-string))
            (overlay (make-overlay position position nil t t)))
@@ -926,13 +933,12 @@ Works with both subprocess-based and MCP-based REPLs."
           (push msg result))))
     (nreverse result)))
 
-(defun unison-ts--display-mcp-result (result title &optional at)
+(defun unison-ts--display-mcp-result (result title at)
   "Display MCP RESULT appropriately based on content.
 Short success messages go to minibuffer, errors/long output to a buffer.
-AT is a buffer position; when non-nil and the result is a success,
-an inline overlay is shown at that position in addition to the minibuffer
-message.  Defaults to `(point)' when nil."
-  (let ((overlay-position (or at (point))))
+AT is a buffer position; when the result is a success, an inline overlay
+is shown at that position in addition to the minibuffer message."
+  (let ((overlay-position at))
     (if (and result (listp result))
         (let* ((content-array (alist-get 'content result))
                (content (if (vectorp content-array)

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -47,6 +47,47 @@ Set to nil to disable auto-close."
                  (const :tag "Disable" nil))
   :group 'unison-ts-repl)
 
+(defcustom unison-ts-eval-overlay t
+  "When non-nil, display eval results as transient inline overlays.
+When nil, all overlay logic is a no-op and behavior matches the pre-overlay
+default (minibuffer only)."
+  :type 'boolean
+  :group 'unison-ts-repl)
+
+(defcustom unison-ts-eval-overlay-format " => %s"
+  "Format string for inline eval result overlays.
+%s is replaced with the result string."
+  :type 'string
+  :group 'unison-ts-repl)
+
+(defface unison-ts-eval-overlay-face
+  '((t :inherit font-lock-comment-face))
+  "Face used for inline eval result overlays."
+  :group 'unison-ts-repl)
+
+(defvar-local unison-ts--eval-overlay nil
+  "Current eval result overlay in this buffer, or nil.")
+
+(defun unison-ts--overlay-clear ()
+  "Delete the current eval overlay and remove the pre-command hook."
+  (when (overlayp unison-ts--eval-overlay)
+    (delete-overlay unison-ts--eval-overlay))
+  (setq unison-ts--eval-overlay nil)
+  (remove-hook 'pre-command-hook #'unison-ts--overlay-clear t))
+
+(defun unison-ts--overlay-show (position result-string)
+  "Display RESULT-STRING as a transient overlay at POSITION.
+POSITION is a buffer position (integer or marker).
+Does nothing when `unison-ts-eval-overlay' is nil."
+  (when unison-ts-eval-overlay
+    (unison-ts--overlay-clear)
+    (let* ((text (format unison-ts-eval-overlay-format result-string))
+           (overlay (make-overlay position position nil t t)))
+      (overlay-put overlay 'after-string
+                   (propertize text 'face 'unison-ts-eval-overlay-face))
+      (setq unison-ts--eval-overlay overlay)
+      (add-hook 'pre-command-hook #'unison-ts--overlay-clear nil t))))
+
 (defconst unison-ts--lsp-startup-max-attempts 100
   "Maximum attempts to wait for LSP server startup (0.1s each = 10s total).")
 
@@ -885,40 +926,45 @@ Works with both subprocess-based and MCP-based REPLs."
           (push msg result))))
     (nreverse result)))
 
-(defun unison-ts--display-mcp-result (result title)
+(defun unison-ts--display-mcp-result (result title &optional at)
   "Display MCP RESULT appropriately based on content.
-Short success messages go to minibuffer, errors/long output to a buffer."
-  (if (and result (listp result))
-      (let* ((content-array (alist-get 'content result))
-             (content (if (vectorp content-array)
-                          (aref content-array 0)
-                        (car content-array)))
-             (text (alist-get 'text content))
-             (parsed (when text (unison-ts--parse-mcp-output text))))
-        (if (and (listp parsed) (not (stringp parsed)))
-            (let* ((errors (unison-ts--dedupe-messages (alist-get 'errorMessages parsed)))
-                   (error-keys (mapcar #'string-trim errors))
-                   (outputs (seq-filter
-                             (lambda (msg)
-                               (and (not (string-match-p "^Loading changes" msg))
-                                    (not (string-match-p "^No changes found" msg))
-                                    ;; Filter misleading "Run `update`" - MCP already commits
-                                    (not (string-match-p "Run `update` to apply" msg))
-                                    (not (member (string-trim msg) error-keys))))
-                             (unison-ts--dedupe-messages (alist-get 'outputMessages parsed)))))
-              (if (= (length errors) 0)
-                  ;; Success → minibuffer with helpful message
-                  (let ((output-str (string-join outputs " ")))
-                    (if (string-match-p "^\\+" output-str)
-                        ;; Definitions were added - show what was added
-                        (message "UCM: Added definitions. %s" output-str)
-                      (message "UCM: %s" output-str)))
-                ;; Errors → buffer
-                (unison-ts--display-in-buffer title errors outputs)))
-          ;; Non-parsed output → buffer
-          (unison-ts--display-in-buffer title nil (list (format "%s" parsed)))))
-    ;; Fallback → buffer
-    (unison-ts--display-in-buffer title nil (list (format "%S" result)))))
+Short success messages go to minibuffer, errors/long output to a buffer.
+AT is a buffer position; when non-nil and the result is a success,
+an inline overlay is shown at that position in addition to the minibuffer
+message.  Defaults to `(point)' when nil."
+  (let ((overlay-position (or at (point))))
+    (if (and result (listp result))
+        (let* ((content-array (alist-get 'content result))
+               (content (if (vectorp content-array)
+                            (aref content-array 0)
+                          (car content-array)))
+               (text (alist-get 'text content))
+               (parsed (when text (unison-ts--parse-mcp-output text))))
+          (if (and (listp parsed) (not (stringp parsed)))
+              (let* ((errors (unison-ts--dedupe-messages (alist-get 'errorMessages parsed)))
+                     (error-keys (mapcar #'string-trim errors))
+                     (outputs (seq-filter
+                               (lambda (msg)
+                                 (and (not (string-match-p "^Loading changes" msg))
+                                      (not (string-match-p "^No changes found" msg))
+                                      ;; Filter misleading "Run `update`" - MCP already commits
+                                      (not (string-match-p "Run `update` to apply" msg))
+                                      (not (member (string-trim msg) error-keys))))
+                               (unison-ts--dedupe-messages (alist-get 'outputMessages parsed)))))
+                (if (= (length errors) 0)
+                    ;; Success → minibuffer + optional overlay
+                    (let ((output-str (string-join outputs " ")))
+                      (if (string-match-p "^\\+" output-str)
+                          ;; Definitions were added - show what was added
+                          (message "UCM: Added definitions. %s" output-str)
+                        (message "UCM: %s" output-str))
+                      (unison-ts--overlay-show overlay-position output-str))
+                  ;; Errors → buffer
+                  (unison-ts--display-in-buffer title errors outputs)))
+            ;; Non-parsed output → buffer
+            (unison-ts--display-in-buffer title nil (list (format "%s" parsed)))))
+      ;; Fallback → buffer
+      (unison-ts--display-in-buffer title nil (list (format "%S" result))))))
 
 (defun unison-ts--display-in-buffer (title errors outputs)
   "Display ERRORS and OUTPUTS in a *UCM: TITLE* buffer.
@@ -948,7 +994,8 @@ Displays result with TITLE when complete."
   (unless buffer-file-name
     (user-error "Buffer is not visiting a file"))
   (let ((code (buffer-substring-no-properties (point-min) (point-max)))
-        (ctx (unison-ts-mcp--get-project-context)))
+        (ctx (unison-ts-mcp--get-project-context))
+        (position (point)))
     (unless ctx
       (user-error "No Unison project context found. Open a project first"))
     (let ((project-name (alist-get 'projectName ctx))
@@ -958,7 +1005,7 @@ Displays result with TITLE when complete."
        (append (unison-ts-mcp--make-project-context project-name branch-name)
                `((code . ((text . ,code)))))
        (lambda (result)
-         (unison-ts--display-mcp-result result title))))))
+         (unison-ts--display-mcp-result result title position))))))
 
 ;;;###autoload
 (defun unison-ts-add ()
@@ -976,7 +1023,8 @@ Displays result with TITLE when complete."
 (defun unison-ts-test ()
   "Run tests in the current project via MCP."
   (interactive)
-  (let ((ctx (unison-ts-mcp--get-project-context)))
+  (let ((ctx (unison-ts-mcp--get-project-context))
+        (position (point)))
     (unless ctx
       (user-error "No Unison project context found. Open a project first"))
     (unison-ts-mcp--call-tool
@@ -985,7 +1033,7 @@ Displays result with TITLE when complete."
       (alist-get 'projectName ctx)
       (alist-get 'branchName ctx))
      (lambda (result)
-       (unison-ts--display-mcp-result result "test")))))
+       (unison-ts--display-mcp-result result "test" position)))))
 
 ;;;###autoload
 (defun unison-ts-eval (expr)
@@ -993,7 +1041,8 @@ Displays result with TITLE when complete."
 EXPR is evaluated using the typecheck-code tool with > prefix.
 Works for both pure functions and IO actions."
   (interactive "sExpression: ")
-  (let ((ctx (unison-ts-mcp--get-project-context)))
+  (let ((ctx (unison-ts-mcp--get-project-context))
+        (position (point)))
     (unless ctx
       (user-error "No Unison project context found. Open a project first"))
     (unison-ts-mcp--call-tool
@@ -1003,7 +1052,7 @@ Works for both pure functions and IO actions."
               (alist-get 'branchName ctx))
              `((code . ((sourceCode . ,(concat "> " expr))))))
      (lambda (result)
-       (unison-ts--display-mcp-result result "eval")))))
+       (unison-ts--display-mcp-result result "eval" position)))))
 
 ;;;###autoload
 (defun unison-ts-run ()
@@ -1011,7 +1060,8 @@ Works for both pure functions and IO actions."
 For pure expressions, use `unison-ts-eval' instead."
   (interactive)
   (let ((term (read-string "IO action to run: "))
-        (ctx (unison-ts-mcp--get-project-context)))
+        (ctx (unison-ts-mcp--get-project-context))
+        (position (point)))
     (unless ctx
       (user-error "No Unison project context found. Open a project first"))
     (unison-ts-mcp--call-tool
@@ -1022,7 +1072,7 @@ For pure expressions, use `unison-ts-eval' instead."
              `((mainFunctionName . ,term)
                (args . [])))
      (lambda (result)
-       (unison-ts--display-mcp-result result "run")))))
+       (unison-ts--display-mcp-result result "run" position)))))
 
 ;;;###autoload
 (defun unison-ts-watch ()
@@ -1031,7 +1081,8 @@ For pure expressions, use `unison-ts-eval' instead."
   (unless buffer-file-name
     (user-error "Buffer is not visiting a file"))
   (let ((code (buffer-substring-no-properties (point-min) (point-max)))
-        (ctx (unison-ts-mcp--get-project-context)))
+        (ctx (unison-ts-mcp--get-project-context))
+        (position (point)))
     (unless ctx
       (user-error "No Unison project context found. Open a project first"))
     (unison-ts-mcp--call-tool
@@ -1041,7 +1092,7 @@ For pure expressions, use `unison-ts-eval' instead."
               (alist-get 'branchName ctx))
              `((code . ((sourceCode . ,code)))))
      (lambda (result)
-       (unison-ts--display-mcp-result result "watch")))))
+       (unison-ts--display-mcp-result result "watch" position)))))
 
 ;;;###autoload
 (defun unison-ts-load ()
@@ -1057,7 +1108,7 @@ For pure expressions, use `unison-ts-eval' instead."
     (user-error "No region active"))
   (let* ((code (buffer-substring-no-properties start end))
          (result (unison-ts-mcp--update-definitions code)))
-    (unison-ts--display-mcp-result result "eval")))
+    (unison-ts--display-mcp-result result "eval" end)))
 
 (defun unison-ts--definition-node-p (node)
   "Return non-nil if NODE is a Unison definition."
@@ -1075,8 +1126,9 @@ For pure expressions, use `unison-ts-eval' instead."
       (unless def-node
         (user-error "Point is not within a definition"))
       (let* ((code (treesit-node-text def-node t))
+             (def-end (treesit-node-end def-node))
              (result (unison-ts-mcp--update-definitions code)))
-        (unison-ts--display-mcp-result result "eval")))))
+        (unison-ts--display-mcp-result result "eval" def-end)))))
 
 (provide 'unison-ts-repl)
 


### PR DESCRIPTION
closes #16

adds cider-style transient inline overlays after successful eval. on error, existing buffer-pop behavior is unchanged.

**new defcustoms** (group `unison-ts-repl`):
- `unison-ts-eval-overlay` (boolean, default `t`) — set to `nil` to disable all overlay logic
- `unison-ts-eval-overlay-format` (string, default `" => %s"`) — prefix format for the result text

**new defface**: `unison-ts-eval-overlay-face` (inherits `font-lock-comment-face`)

the overlay is auto-cleared via a buffer-local `pre-command-hook` that removes itself after firing, so the first keystroke after eval dismisses it.

callers of `unison-ts--display-mcp-result` now capture point (or region/defun end) before the async MCP call and pass it as the optional `at` argument. region commands pass `end`; `unison-ts-send-definition` passes `treesit-node-end`.