### PR TITLE
docs(repl): correct unison-ts--definition-at-point docstring

### DIFF
--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -1130,8 +1130,10 @@ For pure expressions, use `unison-ts-eval' instead."
           '("term_declaration" "type_declaration" "ability_declaration")))
 
 (defun unison-ts--definition-at-point ()
-  "Return the source text of the definition at point.
-Signals `user-error' if point is not on a definition node."
+  "Return (CODE . END) for the definition at point.
+CODE is the source text of the enclosing definition node.  END is
+the buffer position after the node, suitable for anchoring result
+overlays.  Signals `user-error' if point is not on a definition."
   (let ((node (treesit-node-at (point))))
     (unless node
       (user-error "No tree-sitter node at point"))


### PR DESCRIPTION
the function returns `(CODE . END)` since #20 (overlay anchoring) but the docstring still claimed "the source text". update to describe the actual return value.

self-review follow-up to the recent stack (#10, #17, #18, #19, #20). no behavior change. tests 192/192.