### PR TITLE
chore: release v0.3.0

### DIFF
--- a/unison-ts-mode.el
+++ b/unison-ts-mode.el
@@ -5,7 +5,7 @@
 ;; Author: Filipe Guerreiro <filipe.m.guerreiro@gmail.com>
 ;; Maintainer: Filipe Guerreiro <filipe.m.guerreiro@gmail.com>
 ;; Created: November 11, 2023
-;; Version: 0.2.0
+;; Version: 0.3.0
 ;; Package-Requires: ((emacs "29.1"))
 ;; Keywords: languages unison tree-sitter
 ;; URL: https://github.com/fmguerreiro/unison-ts-mode


### PR DESCRIPTION
bump version 0.2.0 to 0.3.0 to release the changes since v0.2.0.

since v0.2.0:
- full UCM in a comint buffer, serving LSP + MCP from one process (gh#8)
- fixes the eglot timeout + ucm-headless pileup in #22
- MCP send race fix (gh#11), project-current root (gh#13)
- eval/send -and-go variants (gh#15), inline eval overlay (gh#16)

cutting this so MELPA ships the gh#8 fix. closes #22.