### PR TITLE
docs(repl): wrap execute-async docstring under 80 columns

### DIFF
--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -558,7 +558,8 @@ Examples:
       (cons 'watch trimmed)))))
 
 (defun unison-ts-mcp-repl--execute-async (command args callback)
-  "Execute MCP COMMAND with ARGS asynchronously, calling CALLBACK with result string."
+  "Execute MCP COMMAND with ARGS asynchronously.
+CALLBACK is called with the result string."
   (let ((default-directory (or unison-ts-mcp-repl--project-root
                                default-directory))
         (repl-buffer (current-buffer)))


### PR DESCRIPTION
`unison-ts-mcp-repl--execute-async` docstring exceeded 80 columns, which fails `scripts/pre-commit`.

split the one-liner into two lines. no behavior change. pre-commit passes clean.