### PR TITLE
refactor(repl): remove dead external-UCM detection (gh#24)

### DIFF
--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -313,41 +313,6 @@ Signals an error if UCM is not found."
 (defvar unison-ts-repl--buffers (make-hash-table :test 'equal :weakness 'value)
   "Hash table mapping project roots to their UCM REPL buffers.")
 
-(defun unison-ts--external-ucm-pids ()
-  "Return list of external UCM process PIDs (not managed by Emacs)."
-  (let ((emacs-ucm-pids (delq nil
-                              (mapcar (lambda (buf)
-                                        (when-let ((proc (get-buffer-process buf)))
-                                          (process-id proc)))
-                                      (hash-table-values unison-ts-repl--buffers))))
-        (all-pids nil))
-    (with-temp-buffer
-      (when (zerop (call-process "pgrep" nil t nil "-x" "ucm"))
-        (setq all-pids (mapcar #'string-to-number
-                               (split-string (buffer-string) "\n" t)))))
-    (seq-difference all-pids emacs-ucm-pids)))
-
-(defun unison-ts--find-ucm-buffer ()
-  "Find any buffer running UCM (term, vterm, eshell, shell, or MCP REPL).
-Returns the buffer or nil."
-  (seq-find (lambda (buf)
-              (with-current-buffer buf
-                (or
-                 ;; MCP REPL mode buffer
-                 (derived-mode-p 'unison-ts-mcp-repl-mode)
-                 ;; Process-based UCM buffer
-                 (and (process-live-p (get-buffer-process buf))
-                      (string-match-p "ucm" (buffer-name buf))))))
-            (buffer-list)))
-
-(defun unison-ts--kill-external-ucm ()
-  "Kill external UCM processes after confirmation."
-  (let ((pids (unison-ts--external-ucm-pids)))
-    (when pids
-      (dolist (pid pids)
-        (signal-process pid 'TERM))
-      (sit-for 0.5))))
-
 ;;; Comint-based REPL (when no headless UCM is running)
 
 (defvar unison-ts-repl-mode-map


### PR DESCRIPTION
fixes #24.

`unison-ts--external-ucm-pids` used `pgrep -x ucm`, which never matches on Homebrew macOS (ucm is a bash wrapper; the real process is `unison`). but the function and its cluster (`unison-ts--find-ucm-buffer`, `unison-ts--kill-external-ucm`) have no callers, are not interactive or autoloaded, and have no test refs. they were never wired up, even before the gh#8 single-inferior-UCM rewrite that made external-UCM management obsolete.

patching the pgrep pattern would polish dead code. removed the cluster instead.

- byte-compile, load-check, pattern checks pass
- no remaining references in any .el