### PR TITLE
chore(grammar): switch to upstream kylegoetz, pinned to 10365cc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        emacs: ['29.1', '29.4']
+        emacs: ['30.1', '30.2']
     steps:
       - uses: actions/checkout@v4
 
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        emacs: ['29.1', '29.4']
+        emacs: ['30.1', '30.2']
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,14 +125,20 @@ jobs:
 
       - name: Build Unison grammar
         run: |
-          git clone --depth 1 https://github.com/fmguerreiro/tree-sitter-unison.git /tmp/tree-sitter-unison
+          git clone https://github.com/kylegoetz/tree-sitter-unison.git /tmp/tree-sitter-unison
           cd /tmp/tree-sitter-unison
+          git checkout 10365cc70ab2b2de85ea7ab35cf6b7636c36ce8b
           tree-sitter generate
           mkdir -p ~/.emacs.d/tree-sitter
-          if [ -f src/parser.c ]; then
-            cc -shared -fPIC -o ~/.emacs.d/tree-sitter/libtree-sitter-unison.so \
-              -I src src/parser.c
-          fi
+          cc -shared -fPIC -o ~/.emacs.d/tree-sitter/libtree-sitter-unison.so \
+            -I src src/parser.c src/scanner.c
+
+      - name: Verify grammar loads
+        run: |
+          emacs --batch \
+            --eval "(add-to-list 'treesit-extra-load-path \"~/.emacs.d/tree-sitter/\")" \
+            --eval "(require 'treesit)" \
+            --eval "(unless (treesit-ready-p 'unison t) (error \"Unison grammar failed to load; grammar tests would silently skip\"))"
 
       - name: Run ERT tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,16 +119,12 @@ jobs:
         with:
           version: ${{ matrix.emacs }}
 
-      - name: Install tree-sitter CLI
-        run: |
-          npm install -g tree-sitter-cli
-
       - name: Build Unison grammar
         run: |
-          git clone https://github.com/kylegoetz/tree-sitter-unison.git /tmp/tree-sitter-unison
+          git clone --filter=blob:none --no-checkout \
+            https://github.com/kylegoetz/tree-sitter-unison.git /tmp/tree-sitter-unison
           cd /tmp/tree-sitter-unison
           git checkout 10365cc70ab2b2de85ea7ab35cf6b7636c36ce8b
-          tree-sitter generate
           mkdir -p ~/.emacs.d/tree-sitter
           cc -shared -fPIC -o ~/.emacs.d/tree-sitter/libtree-sitter-unison.so \
             -I src src/parser.c src/scanner.c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        emacs: ['30.1', '30.2']
+        emacs: ['29.1', '29.4', '30.1', '30.2']
     steps:
       - uses: actions/checkout@v4
 
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        emacs: ['30.1', '30.2']
+        emacs: ['29.1', '29.4', '30.1', '30.2']
     steps:
       - uses: actions/checkout@v4
 
@@ -124,7 +124,7 @@ jobs:
           git clone --filter=blob:none --no-checkout \
             https://github.com/kylegoetz/tree-sitter-unison.git /tmp/tree-sitter-unison
           cd /tmp/tree-sitter-unison
-          git checkout 10365cc70ab2b2de85ea7ab35cf6b7636c36ce8b
+          git checkout 662bf52b966108cf299090a238cd6abfb65d5170
           mkdir -p ~/.emacs.d/tree-sitter
           cc -shared -fPIC -o ~/.emacs.d/tree-sitter/libtree-sitter-unison.so \
             -I src src/parser.c src/scanner.c

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ emacs --batch -L . -f batch-byte-compile unison-ts-mode.el unison-ts-font-lock.e
 
 ## Tree-sitter Grammar
 
-Requires the Unison tree-sitter grammar from `https://github.com/kylegoetz/tree-sitter-unison`, pinned to a verified commit via `unison-ts-grammar-revision`. Grammar installs automatically when opening a `.u` file (controlled by `unison-ts-grammar-install` customization).
+Requires the Unison tree-sitter grammar from `https://github.com/kylegoetz/tree-sitter-unison`, pinned to commit `10365cc70ab2b2de85ea7ab35cf6b7636c36ce8b` via `unison-ts-grammar-revision`. Grammar installs automatically when opening a `.u` file (controlled by `unison-ts-grammar-install` customization).
 
 ## UCM Keybindings
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Emacs major mode for the Unison programming language using tree-sitter for syntax highlighting and indentation. Requires Emacs 30+ with native tree-sitter support (on Emacs 29's older tree-sitter runtime the pinned grammar misparses `let` and `handle` expressions). Files with `.u` or `.unison` extensions activate this mode.
+Emacs major mode for the Unison programming language using tree-sitter for syntax highlighting and indentation. Requires Emacs 29+ with native tree-sitter support. Files with `.u` or `.unison` extensions activate this mode.
 
 ## Architecture
 
@@ -40,7 +40,9 @@ emacs --batch -L . -f batch-byte-compile unison-ts-mode.el unison-ts-font-lock.e
 
 ## Tree-sitter Grammar
 
-Requires the Unison tree-sitter grammar from `https://github.com/kylegoetz/tree-sitter-unison`, pinned to commit `10365cc70ab2b2de85ea7ab35cf6b7636c36ce8b` via `unison-ts-grammar-revision`. Grammar installs automatically when opening a `.u` file (controlled by `unison-ts-grammar-install` customization).
+Requires the Unison tree-sitter grammar from `https://github.com/kylegoetz/tree-sitter-unison`, pinned to commit `662bf52b966108cf299090a238cd6abfb65d5170` via `unison-ts-grammar-revision`. Grammar installs automatically when opening a `.u` file (controlled by `unison-ts-grammar-install` customization).
+
+Do not bump the pin to a newer upstream commit without testing on Emacs 29 and 30. Commits after `b2ae57b` (2026-02-05) were regenerated with a newer tree-sitter CLI and misparse `let`/`handle` expressions on the tree-sitter runtime bundled with Emacs 29 and some Emacs 30 builds.
 
 ## UCM Keybindings
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Emacs major mode for the Unison programming language using tree-sitter for syntax highlighting and indentation. Requires Emacs 29+ with native tree-sitter support. Files with `.u` or `.unison` extensions activate this mode.
+Emacs major mode for the Unison programming language using tree-sitter for syntax highlighting and indentation. Requires Emacs 30+ with native tree-sitter support (the pinned grammar misparses `let`/`handle` expressions on Emacs 29's older tree-sitter runtime). Files with `.u` or `.unison` extensions activate this mode.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ emacs --batch -L . -f batch-byte-compile unison-ts-mode.el unison-ts-font-lock.e
 
 Requires the Unison tree-sitter grammar from `https://github.com/kylegoetz/tree-sitter-unison`, pinned to commit `662bf52b966108cf299090a238cd6abfb65d5170` via `unison-ts-grammar-revision`. Grammar installs automatically when opening a `.u` file (controlled by `unison-ts-grammar-install` customization).
 
-Do not bump the pin to a newer upstream commit without testing on Emacs 29 and 30. Commits after `b2ae57b` (2026-02-05) were regenerated with a newer tree-sitter CLI and misparse `let`/`handle` expressions on the tree-sitter runtime bundled with Emacs 29 and some Emacs 30 builds.
+Do not bump the pin to a newer upstream commit without testing on Emacs 29 and 30. The pin is the parent of `b2ae57b` (2026-02-05); that commit and later were regenerated with a newer tree-sitter CLI and misparse `let`/`handle` expressions on the older tree-sitter runtimes bundled with Emacs 29 and some Emacs 30 builds.
 
 ## UCM Keybindings
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ emacs --batch -L . -f batch-byte-compile unison-ts-mode.el unison-ts-font-lock.e
 
 ## Tree-sitter Grammar
 
-Requires the Unison tree-sitter grammar from `https://github.com/fmguerreiro/tree-sitter-unison`. Grammar installs automatically when opening a `.u` file (controlled by `unison-ts-grammar-install` customization).
+Requires the Unison tree-sitter grammar from `https://github.com/kylegoetz/tree-sitter-unison`, pinned to a verified commit via `unison-ts-grammar-revision`. Grammar installs automatically when opening a `.u` file (controlled by `unison-ts-grammar-install` customization).
 
 ## UCM Keybindings
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Emacs major mode for the Unison programming language using tree-sitter for syntax highlighting and indentation. Requires Emacs 30+ with native tree-sitter support (the pinned grammar misparses `let`/`handle` expressions on Emacs 29's older tree-sitter runtime). Files with `.u` or `.unison` extensions activate this mode.
+Emacs major mode for the Unison programming language using tree-sitter for syntax highlighting and indentation. Requires Emacs 30+ with native tree-sitter support (on Emacs 29's older tree-sitter runtime the pinned grammar misparses `let` and `handle` expressions). Files with `.u` or `.unison` extensions activate this mode.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Emacs major mode for [Unison](https://www.unison-lang.org/) using tree-sitter.
 
 ## Requirements
 
-- Emacs 30+ (the pinned grammar needs the tree-sitter runtime bundled with Emacs 30; on Emacs 29 `let` and `handle` expressions misparse)
+- Emacs 29+ (with native tree-sitter support)
 - [Unison tree-sitter grammar](https://github.com/kylegoetz/tree-sitter-unison) (auto-installed)
 
 ## Installation
@@ -207,7 +207,7 @@ If auto-install fails:
 ```sh
 git clone https://github.com/kylegoetz/tree-sitter-unison.git
 cd tree-sitter-unison
-git checkout 10365cc70ab2b2de85ea7ab35cf6b7636c36ce8b
+git checkout 662bf52b966108cf299090a238cd6abfb65d5170
 
 # Determine shared library extension
 if [ "$(uname)" = "Darwin" ]; then soext="dylib"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Emacs major mode for [Unison](https://www.unison-lang.org/) using tree-sitter.
 
 ## Requirements
 
-- Emacs 29+ (with native tree-sitter support)
+- Emacs 30+ (the pinned grammar needs the tree-sitter runtime bundled with Emacs 30; on Emacs 29 `let` and `handle` expressions misparse)
 - [Unison tree-sitter grammar](https://github.com/kylegoetz/tree-sitter-unison) (auto-installed)
 
 ## Installation
@@ -102,7 +102,7 @@ Navigate to functions, types, and abilities:
 
 Requires [UCM](https://www.unison-lang.org/docs/install-instructions/). UCM auto-starts as the inferior UCM (full TUI in a comint buffer) the first time eglot, lsp-mode, or the REPL needs it. The same process serves LSP, MCP, and the user-facing TUI, so there is no codebase-lock conflict.
 
-**Eglot (built-in Emacs 29+):**
+**Eglot (built-in):**
 
 ```elisp
 (with-eval-after-load 'unison-ts-mode

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Emacs major mode for [Unison](https://www.unison-lang.org/) using tree-sitter.
 ## Requirements
 
 - Emacs 29+ (with native tree-sitter support)
-- [Unison tree-sitter grammar](https://github.com/fmguerreiro/tree-sitter-unison) (auto-installed)
+- [Unison tree-sitter grammar](https://github.com/kylegoetz/tree-sitter-unison) (auto-installed)
 
 ## Installation
 
@@ -205,8 +205,9 @@ Ensure you're in a valid Unison codebase directory.
 If auto-install fails:
 
 ```sh
-git clone https://github.com/fmguerreiro/tree-sitter-unison.git
+git clone https://github.com/kylegoetz/tree-sitter-unison.git
 cd tree-sitter-unison
+git checkout 10365cc70ab2b2de85ea7ab35cf6b7636c36ce8b
 
 # Determine shared library extension
 if [ "$(uname)" = "Darwin" ]; then soext="dylib"

--- a/unison-ts-install.el
+++ b/unison-ts-install.el
@@ -32,14 +32,16 @@
                  (const :tag "Never auto-install" nil))
   :group 'unison-ts)
 
-(defcustom unison-ts-grammar-repository "https://github.com/fmguerreiro/tree-sitter-unison"
+(defcustom unison-ts-grammar-repository "https://github.com/kylegoetz/tree-sitter-unison"
   "Repository URL for the Unison tree-sitter grammar."
   :type 'string
   :group 'unison-ts)
 
-(defcustom unison-ts-grammar-revision nil
+(defcustom unison-ts-grammar-revision "10365cc70ab2b2de85ea7ab35cf6b7636c36ce8b"
   "Git revision (branch, tag, or commit) for the grammar.
-If nil, uses the default branch."
+If nil, uses the default branch.
+Pinned to a verified upstream commit; bump after re-running the test
+suite against a newer revision."
   :type '(choice (const :tag "Default branch" nil)
                  (string :tag "Branch/tag/commit"))
   :group 'unison-ts)

--- a/unison-ts-install.el
+++ b/unison-ts-install.el
@@ -41,9 +41,10 @@
   "Git revision (branch, tag, or commit) for the grammar.
 If nil, uses the default branch.
 Pinned to the last upstream commit whose generated parser runs on the
-tree-sitter runtime bundled with Emacs 29.  Later upstream commits were
+older tree-sitter runtimes bundled with Emacs 29 and some Emacs 30
+builds.  Commit b2ae57b (the child of this pin) and later were
 regenerated with a newer tree-sitter CLI and misparse `let'/`handle'
-expressions on older runtimes; bump only after verifying a newer
+expressions on those runtimes; bump only after verifying a newer
 revision against Emacs 29 and 30."
   :type '(choice (const :tag "Default branch" nil)
                  (string :tag "Branch/tag/commit"))

--- a/unison-ts-install.el
+++ b/unison-ts-install.el
@@ -37,11 +37,14 @@
   :type 'string
   :group 'unison-ts)
 
-(defcustom unison-ts-grammar-revision "10365cc70ab2b2de85ea7ab35cf6b7636c36ce8b"
+(defcustom unison-ts-grammar-revision "662bf52b966108cf299090a238cd6abfb65d5170"
   "Git revision (branch, tag, or commit) for the grammar.
 If nil, uses the default branch.
-Pinned to a verified upstream commit; bump after re-running the test
-suite against a newer revision."
+Pinned to the last upstream commit whose generated parser runs on the
+tree-sitter runtime bundled with Emacs 29.  Later upstream commits were
+regenerated with a newer tree-sitter CLI and misparse `let'/`handle'
+expressions on older runtimes; bump only after verifying a newer
+revision against Emacs 29 and 30."
   :type '(choice (const :tag "Default branch" nil)
                  (string :tag "Branch/tag/commit"))
   :group 'unison-ts)

--- a/unison-ts-mode.el
+++ b/unison-ts-mode.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Filipe Guerreiro <filipe.m.guerreiro@gmail.com>
 ;; Created: November 11, 2023
 ;; Version: 0.3.0
-;; Package-Requires: ((emacs "30.1"))
+;; Package-Requires: ((emacs "29.1"))
 ;; Keywords: languages unison tree-sitter
 ;; URL: https://github.com/fmguerreiro/unison-ts-mode
 

--- a/unison-ts-mode.el
+++ b/unison-ts-mode.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Filipe Guerreiro <filipe.m.guerreiro@gmail.com>
 ;; Created: November 11, 2023
 ;; Version: 0.3.0
-;; Package-Requires: ((emacs "29.1"))
+;; Package-Requires: ((emacs "30.1"))
 ;; Keywords: languages unison tree-sitter
 ;; URL: https://github.com/fmguerreiro/unison-ts-mode
 


### PR DESCRIPTION
Replace our stale fork (`fmguerreiro/tree-sitter-unison`, frozen Nov 2025) with the actively-maintained upstream `kylegoetz/tree-sitter-unison`, pinned to commit `662bf52`.

## Why
Our fork diverged in Mar 2025 with 8 grammar patches. Upstream added many commits since, independently fixing every problem area our fork patched (destructuring binds, use clauses in blocks, inline-comment scanning) and adding the real `@unison/base` library as a test corpus (parse failures driven from 250+ down to ~103). Tracking upstream ends maintenance of the fork.

## Which commit, and why not the latest
The newest upstream (`10365cc`, Feb 27) regenerated its parser with a newer tree-sitter CLI whose tables require a libtree-sitter runtime that many Emacs builds do not ship — including CI's Emacs 30. On those runtimes it parses `let` and `handle` expressions into `ERROR` nodes, breaking keyword highlighting and indentation.

A bisect traced the break to upstream `b2ae57b` (2026-02-05). Its parent, `662bf52`, is the last commit before that regenerate; it parses correctly on every runtime tested. So the pin is `662bf52`: nearly all upstream improvements, no runtime-portability regression, Emacs 29 support retained. The trade-off is ~8 upstream commits after Feb 5 (effect-binding and comment-scanner fixes among them); `unison-ts-grammar-revision` and CLAUDE.md document not bumping past `b2ae57b` without testing on Emacs 29 and 30.

## CI fixes (found in review)
- CI cloned the old fork at its default branch and compiled only `parser.c`. On Linux the scanner-less `.so` fails to load, so `treesit-ready-p` returned nil and the 146 grammar tests **silently skipped** while CI still reported "192 passed".
- Now clones upstream at the pin, compiles the committed `parser.c` + `scanner.c` (matching `treesit-install-language-grammar`), and adds a step that fails CI if the grammar does not load.
- CI matrix expanded to Emacs 29.1/29.4/30.1/30.2 to guard runtime portability.

## Verification
All 8 CI jobs green (lint + test on Emacs 29.1/29.4/30.1/30.2). 192/192 tests pass, 146 of them exercising the grammar via font-lock/indent.

## Follow-up
`unison-ts-install-grammar` swallows install errors in a `condition-case` (pre-existing) — tracked separately, not in scope here.