### PR TITLE
fix(install): propagate grammar install failures

### DIFF
--- a/unison-ts-install.el
+++ b/unison-ts-install.el
@@ -54,26 +54,35 @@ revision against Emacs 29 and 30."
   "Whether we've already prompted for installation this session.")
 
 (defun unison-ts-install-grammar ()
-  "Install tree-sitter grammar for Unison."
+  "Install tree-sitter grammar for Unison.
+Signal an error if cloning, checkout, or building the grammar fails;
+the grammar is pinned to a specific revision and a partial install
+would silently degrade syntax highlighting."
   (interactive)
   (unless (assoc 'unison treesit-language-source-alist)
     (add-to-list 'treesit-language-source-alist
                  (if unison-ts-grammar-revision
                      (list 'unison unison-ts-grammar-repository unison-ts-grammar-revision)
                    (list 'unison unison-ts-grammar-repository))))
+  (message "Installing Unison grammar...")
   (condition-case err
       (progn
-        (message "Installing Unison grammar...")
         (treesit-install-language-grammar 'unison)
         (message "Unison grammar installed successfully")
         t)
     (error
-     (message "Failed to install Unison grammar: %s" (error-message-string err))
-     nil)))
+     (signal (car err)
+             (list (format "Failed to install Unison grammar from %s%s: %s"
+                           unison-ts-grammar-repository
+                           (if unison-ts-grammar-revision
+                               (format " (revision %s)" unison-ts-grammar-revision)
+                             "")
+                           (error-message-string err)))))))
 
 (defun unison-ts-ensure-grammar ()
   "Ensure tree-sitter grammar for Unison is installed.
-Returns t if grammar is available, nil otherwise."
+Return t if grammar is available, nil if installation was declined or
+disabled.  Signal an error if an attempted installation fails."
   (cond
    ((treesit-language-available-p 'unison)
     t)

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1695,5 +1695,47 @@ the parser routes to the 'add command."
     (should (eq (car parsed) 'add))
     (should (equal (cdr parsed) "foo = 1\nbar = 2"))))
 
+;;; Grammar installation - fail-fast behavior
+
+(ert-deftest unison-ts-install/propagates-failure ()
+  "A clone/checkout/build failure must propagate, not return nil."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (let ((treesit-language-source-alist treesit-language-source-alist)
+        (unison-ts--install-prompted nil))
+    (cl-letf (((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) (error "clone failed"))))
+      (should-error (unison-ts-install-grammar) :type 'error))))
+
+(ert-deftest unison-ts-install/error-names-repository ()
+  "The propagated error names the repository and revision for context."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (let ((treesit-language-source-alist treesit-language-source-alist)
+        (unison-ts--install-prompted nil)
+        (unison-ts-grammar-repository "https://example.invalid/grammar")
+        (unison-ts-grammar-revision "abc123"))
+    (cl-letf (((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) (error "clone failed"))))
+      (let ((signaled-message
+             (condition-case err
+                 (progn (unison-ts-install-grammar) nil)
+               (error (error-message-string err)))))
+        (should (equal
+                 signaled-message
+                 (concat "Failed to install Unison grammar from "
+                         "https://example.invalid/grammar (revision abc123): "
+                         "clone failed")))))))
+
+(ert-deftest unison-ts-install/returns-t-on-success ()
+  "A successful install returns t."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (let ((treesit-language-source-alist treesit-language-source-alist)
+        (unison-ts--install-prompted nil))
+    (cl-letf (((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) t)))
+      (should (eq (unison-ts-install-grammar) t)))))
+
 (provide 'unison-ts-mode-tests)
 ;;; unison-ts-mode-tests.el ends here


### PR DESCRIPTION
## Problem

`unison-ts-install-grammar` wrapped `treesit-install-language-grammar` in a `condition-case` that caught every error, emitted a `message`, and returned `nil`. With the grammar now pinned to a specific revision, a failed clone, checkout, or build degraded silently to a message-level notice instead of surfacing — violating the project's fail-fast style.

## Change

- Re-signal install failures with the same error symbol, enriched with the repository and revision for context, rather than swallowing them and returning `nil`.
- Update the `unison-ts-ensure-grammar` docstring to reflect that an attempted install may now signal.

## Tests

Three ERT tests added in `unison-ts-mode-tests.el`, each isolating global state and faking `treesit-install-language-grammar`:

- `propagates-failure` — a build failure signals rather than returns `nil`.
- `error-names-repository` — the signaled message names the repository and revision.
- `returns-t-on-success` — a successful install returns `t`.

Full suite (195 tests) and `scripts/pre-commit` pass.

Closes unison-ts-mode-tjr


<!-- archie:start -->

## Diagram Analysis

### install error handling: before and after

failed clone, checkout, or build now re-signals instead of returning nil.

```mermaid
flowchart TD
    A[unison-ts-install-grammar] --> B[treesit-install-language-grammar]
    B --> C{install fails?}
    C -->|before| D[condition-case catches error]
    D --> E[message-level notice]
    E --> F[return nil, silent degrade]
    C -->|after| G[re-signal same error symbol]
    G --> H[enriched with repository and revision]
```

### grammar install call chain

error propagates from treesit up to the caller instead of stopping at install.

```mermaid
sequenceDiagram
    participant Caller
    participant Ensure as unison-ts-ensure-grammar
    participant Install as unison-ts-install-grammar
    participant Treesit as treesit-install-language-grammar
    Caller->>Ensure: ensure grammar present
    Ensure->>Install: install pinned revision
    Install->>Treesit: clone, checkout, build
    Treesit--xInstall: failure
    Install--xEnsure: re-signal with repo and revision
    Ensure--xCaller: error propagates, no silent nil
```
<!-- archie:end -->

