### PR TITLE
fix(repl): use lsof/ss to check LSP port instead of TCP probe

### DIFF
--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1329,6 +1329,25 @@ at `~/.unison/' so the walk always terminates at home."
   (let ((unison-ts-lsp-port 59998))
     (should-not (unison-ts-api--lsp-running-p))))
 
+(ert-deftest unison-ts-api/port-open-p-detects-listener ()
+  "`unison-ts-api--port-open-p' must return non-nil only for a port
+with a live listener.  Regression guard for gh#31 (see that
+function's docstring for the ss false-positive it guards against)."
+  (require 'unison-ts-repl)
+  (unless (or (executable-find "lsof") (executable-find "ss"))
+    (ert-skip "neither lsof nor ss available"))
+  (let* ((port 59771)
+         (server (make-network-process
+                  :name "unison-test-listener"
+                  :server t
+                  :host "127.0.0.1"
+                  :service port
+                  :family 'ipv4)))
+    (unwind-protect
+        (should (unison-ts-api--port-open-p port))
+      (delete-process server))
+    (should-not (unison-ts-api--port-open-p port))))
+
 (ert-deftest unison-ts-api/repl-start-checks-lsp ()
   "REPL start should check for LSP conflicts."
   (require 'unison-ts-repl)

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -278,16 +278,18 @@ Uses the UNISON_LSP_PORT env var when set, falling back to the
     unison-ts-lsp-port))
 
 (defun unison-ts-api--port-open-p (port)
-  "Return non-nil if PORT is accepting connections on localhost."
-  (condition-case nil
-      (let ((proc (make-network-process
-                   :name "unison-port-check"
-                   :host unison-ts-api-host
-                   :service port
-                   :nowait nil)))
-        (delete-process proc)
-        t)
-    (error nil)))
+  "Return non-nil if PORT is listening on localhost.
+Uses lsof (macOS/BSD) or ss (Linux) to check without opening a
+TCP connection, which poisons UCM's LSP listener."
+  (cond
+   ((executable-find "lsof")
+    (zerop (call-process "lsof" nil nil nil
+                         "-i" (format "TCP:%d" port)
+                         "-sTCP:LISTEN" "-P" "-n")))
+   ((executable-find "ss")
+    (zerop (call-process "ss" nil nil nil
+                         "-tln" (format "sport = :%d" port))))
+   (t nil)))
 
 (defun unison-ts-api--lsp-running-p ()
   "Return non-nil if UCM LSP server is running."

--- a/unison-ts-repl.el
+++ b/unison-ts-repl.el
@@ -256,11 +256,6 @@ Signals an error if no project context is found."
 
 ;;; UCM Headless Detection
 
-(defcustom unison-ts-api-host "localhost"
-  "Host for the UCM codebase server API."
-  :type 'string
-  :group 'unison-ts-repl)
-
 (defcustom unison-ts-lsp-port 5757
   "Port for the UCM LSP server.
 This is the default port UCM uses for LSP (language server protocol).
@@ -277,18 +272,27 @@ Uses the UNISON_LSP_PORT env var when set, falling back to the
       (string-to-number env)
     unison-ts-lsp-port))
 
+(defun unison-ts-api--command-prints-p (program &rest args)
+  "Run PROGRAM with ARGS and return non-nil if it prints any stdout.
+Stderr is discarded so a tool diagnostic (permission warning, an
+unknown-flag error on an older ss) cannot masquerade as output."
+  (with-temp-buffer
+    (apply #'call-process program nil (list t nil) nil args)
+    (> (buffer-size) 0)))
+
 (defun unison-ts-api--port-open-p (port)
-  "Return non-nil if PORT is listening on localhost.
-Uses lsof (macOS/BSD) or ss (Linux) to check without opening a
-TCP connection, which poisons UCM's LSP listener."
+  "Return non-nil if PORT has a live listener on the local machine.
+Uses lsof (macOS/BSD) or ss (Linux) to check without opening a TCP
+connection, which poisons UCM's LSP listener.  Both branches
+require a matching line of stdout, not merely a zero exit: ss exits
+0 for any successful query even when nothing is listening."
   (cond
    ((executable-find "lsof")
-    (zerop (call-process "lsof" nil nil nil
-                         "-i" (format "TCP:%d" port)
-                         "-sTCP:LISTEN" "-P" "-n")))
+    (unison-ts-api--command-prints-p
+     "lsof" "-i" (format "TCP:%d" port) "-sTCP:LISTEN" "-P" "-n"))
    ((executable-find "ss")
-    (zerop (call-process "ss" nil nil nil
-                         "-tln" (format "sport = :%d" port))))
+    (unison-ts-api--command-prints-p
+     "ss" "-tlnH" (format "sport = :%d" port)))
    (t nil)))
 
 (defun unison-ts-api--lsp-running-p ()


### PR DESCRIPTION
Checking the LSP port by opening a TCP connection poisons UCM's listener: it treats each bare connection as an LSP session attempt and stops completing the handshake after a couple of aborted ones. The startup loop probes up to 100 times over 10s, so Eglot times out even though UCM reports the port open.

Query the kernel socket table instead, via `lsof` (macOS/BSD) or `ss` (Linux), and decide on a matching line of stdout rather than the exit code, since `ss` exits 0 for any successful query even when nothing is listening. The shared helper discards stderr so a tool diagnostic can't fake a match; an old `ss` without `-H` reports the port closed and falls back to the REPL rather than false-positive.

Regression test binds a real listener and asserts detection flips on teardown. Full suite green (196/196) on macOS, Emacs 30.1.
