### PR TITLE
fix(install): clone pinned grammar locally and verify availability

### DIFF
--- a/unison-ts-install.el
+++ b/unison-ts-install.el
@@ -78,7 +78,10 @@ revision against Emacs 29 and 30."
 SHA, so this fetches the revision into a temporary directory and points
 a local branch at it before registering that branch as the source.  The
 branch exists for Emacs 29, which clones the source with `-b'; Emacs 30
-runs `git checkout' in place and would take the SHA directly."
+runs `git checkout' in place and would take the SHA directly.
+
+With no revision there is nothing to pin, so treesit clones the
+repository's default branch directly."
   (if (null unison-ts-grammar-revision)
       (let ((treesit-language-source-alist
              (list (list 'unison unison-ts-grammar-repository))))

--- a/unison-ts-install.el
+++ b/unison-ts-install.el
@@ -22,6 +22,8 @@
 
 ;;; Code:
 
+(require 'treesit)
+
 (defcustom unison-ts-grammar-install 'prompt
   "Control automatic grammar installation.
 - prompt: Ask before installing (default)
@@ -53,36 +55,82 @@ revision against Emacs 29 and 30."
 (defvar unison-ts--install-prompted nil
   "Whether we've already prompted for installation this session.")
 
+(defconst unison-ts--grammar-revision-branch "unison-ts-pinned-revision"
+  "Local branch name pointed at `unison-ts-grammar-revision' during install.")
+
+(defun unison-ts--run-git (directory &rest arguments)
+  "Run git with ARGUMENTS in DIRECTORY, signaling on a non-zero exit."
+  (let ((default-directory (file-name-as-directory directory)))
+    (with-temp-buffer
+      (let ((status (apply #'call-process "git" nil t nil arguments)))
+        (unless (eq status 0)
+          (error "git %s failed: %s"
+                 (string-join arguments " ")
+                 (string-trim (buffer-string))))))))
+
+(defun unison-ts--install-grammar ()
+  "Clone the pinned grammar and install it into tree-sitter.
+Emacs hands `unison-ts-grammar-revision' to `git clone -b', which
+resolves only branch and tag names, so the raw commit SHA the grammar
+is pinned to can never be cloned that way.  Clone the repository into a
+temporary directory, point a local branch at the revision, and register
+that directory and branch as the grammar source.  Emacs 30 checks the
+branch out in place; Emacs 29 clones it with `-b'; both land on the
+pinned commit.
+
+With no revision there is nothing to pin, so treesit clones the
+repository's default branch directly."
+  (if (null unison-ts-grammar-revision)
+      (let ((treesit-language-source-alist
+             (list (list 'unison unison-ts-grammar-repository))))
+        (treesit-install-language-grammar 'unison))
+    (let ((clone-directory (make-temp-file "unison-ts-grammar-" t)))
+      (unwind-protect
+          (progn
+            ;; Full clone, not --depth 1: the pinned revision predates the
+            ;; default-branch tip, so a shallow clone would not contain the
+            ;; object `git branch' needs to point at.
+            (unison-ts--run-git clone-directory
+                                "clone" unison-ts-grammar-repository ".")
+            (unison-ts--run-git clone-directory "branch"
+                                unison-ts--grammar-revision-branch
+                                unison-ts-grammar-revision)
+            (let ((treesit-language-source-alist
+                   (list (list 'unison clone-directory
+                               unison-ts--grammar-revision-branch))))
+              (treesit-install-language-grammar 'unison)))
+        (delete-directory clone-directory t)))))
+
 (defun unison-ts-install-grammar ()
   "Install tree-sitter grammar for Unison.
-Signal an error if cloning, checkout, or building the grammar fails;
-the grammar is pinned to a specific revision and a partial install
-would silently degrade syntax highlighting."
+Return t if the grammar is available afterward, nil otherwise.  Emacs
+demotes tree-sitter install failures to warnings, so success is
+confirmed with `treesit-language-available-p' rather than by trusting
+that the install call signaled or returned non-nil."
   (interactive)
-  (unless (assoc 'unison treesit-language-source-alist)
-    (add-to-list 'treesit-language-source-alist
-                 (if unison-ts-grammar-revision
-                     (list 'unison unison-ts-grammar-repository unison-ts-grammar-revision)
-                   (list 'unison unison-ts-grammar-repository))))
   (message "Installing Unison grammar...")
-  (condition-case err
-      (progn
-        (treesit-install-language-grammar 'unison)
-        (message "Unison grammar installed successfully")
-        t)
-    (error
-     (signal (car err)
-             (list (format "Failed to install Unison grammar from %s%s: %s"
-                           unison-ts-grammar-repository
-                           (if unison-ts-grammar-revision
-                               (format " (revision %s)" unison-ts-grammar-revision)
-                             "")
-                           (error-message-string err)))))))
+  (let ((install-error
+         (condition-case err
+             (progn (unison-ts--install-grammar) nil)
+           (error (error-message-string err)))))
+    (if (treesit-language-available-p 'unison)
+        (progn
+          (message "Unison grammar installed successfully")
+          t)
+      (message "Failed to install Unison grammar from %s%s%s"
+               unison-ts-grammar-repository
+               (if unison-ts-grammar-revision
+                   (format " (revision %s)" unison-ts-grammar-revision)
+                 "")
+               (if install-error
+                   (format ": %s" install-error)
+                 "; see the tree-sitter error in the *Warnings* buffer"))
+      nil)))
 
 (defun unison-ts-ensure-grammar ()
   "Ensure tree-sitter grammar for Unison is installed.
-Return t if grammar is available, nil if installation was declined or
-disabled.  Signal an error if an attempted installation fails."
+Return t if the grammar is available, nil if it is unavailable and
+installation was declined, disabled, or failed."
   (cond
    ((treesit-language-available-p 'unison)
     t)

--- a/unison-ts-install.el
+++ b/unison-ts-install.el
@@ -64,19 +64,17 @@ revision against Emacs 29 and 30."
     (with-temp-buffer
       (let ((status (apply #'call-process "git" nil t nil arguments)))
         (unless (eq status 0)
-          (error "git %s failed: %s"
+          (error "Git %s failed: %s"
                  (string-join arguments " ")
                  (string-trim (buffer-string))))))))
 
 (defun unison-ts--install-grammar ()
   "Clone the pinned grammar and install it into tree-sitter.
-Emacs hands `unison-ts-grammar-revision' to `git clone -b', which
-resolves only branch and tag names, so the raw commit SHA the grammar
-is pinned to can never be cloned that way.  Clone the repository into a
-temporary directory, point a local branch at the revision, and register
-that directory and branch as the grammar source.  Emacs 30 checks the
-branch out in place; Emacs 29 clones it with `-b'; both land on the
-pinned commit.
+`git clone -b' resolves only branch and tag names, never a raw commit
+SHA, so this fetches the revision into a temporary directory and points
+a local branch at it before registering that branch as the source.  The
+branch exists for Emacs 29, which clones the source with `-b'; Emacs 30
+runs `git checkout' in place and would take the SHA directly.
 
 With no revision there is nothing to pin, so treesit clones the
 repository's default branch directly."
@@ -87,14 +85,15 @@ repository's default branch directly."
     (let ((clone-directory (make-temp-file "unison-ts-grammar-" t)))
       (unwind-protect
           (progn
-            ;; Full clone, not --depth 1: the pinned revision predates the
-            ;; default-branch tip, so a shallow clone would not contain the
-            ;; object `git branch' needs to point at.
-            (unison-ts--run-git clone-directory
-                                "clone" unison-ts-grammar-repository ".")
+            ;; Shallow-fetch just the pinned commit; the full history is
+            ;; ~20x the download for one commit.
+            (unison-ts--run-git clone-directory "init" "--quiet")
+            (unison-ts--run-git clone-directory "remote" "add" "origin"
+                                unison-ts-grammar-repository)
+            (unison-ts--run-git clone-directory "fetch" "--quiet" "--depth" "1"
+                                "origin" unison-ts-grammar-revision)
             (unison-ts--run-git clone-directory "branch"
-                                unison-ts--grammar-revision-branch
-                                unison-ts-grammar-revision)
+                                unison-ts--grammar-revision-branch "FETCH_HEAD")
             (let ((treesit-language-source-alist
                    (list (list 'unison clone-directory
                                unison-ts--grammar-revision-branch))))
@@ -117,7 +116,9 @@ that the install call signaled or returned non-nil."
         (progn
           (message "Unison grammar installed successfully")
           t)
-      (message "Failed to install Unison grammar from %s%s%s"
+      (display-warning
+       'unison-ts
+       (format "Failed to install Unison grammar from %s%s%s"
                unison-ts-grammar-repository
                (if unison-ts-grammar-revision
                    (format " (revision %s)" unison-ts-grammar-revision)
@@ -125,6 +126,7 @@ that the install call signaled or returned non-nil."
                (if install-error
                    (format ": %s" install-error)
                  "; see the tree-sitter error in the *Warnings* buffer"))
+       :error)
       nil)))
 
 (defun unison-ts-ensure-grammar ()

--- a/unison-ts-install.el
+++ b/unison-ts-install.el
@@ -35,7 +35,11 @@
   :group 'unison-ts)
 
 (defcustom unison-ts-grammar-repository "https://github.com/kylegoetz/tree-sitter-unison"
-  "Repository URL for the Unison tree-sitter grammar."
+  "Repository URL for the Unison tree-sitter grammar.
+When `unison-ts-grammar-revision' is a raw commit SHA the host must allow
+fetching unadvertised objects (`uploadpack.allowReachableSHA1InWant'),
+which GitHub does but a self-hosted mirror may not; a branch or tag name
+fetches from any host."
   :type 'string
   :group 'unison-ts)
 
@@ -69,36 +73,32 @@ revision against Emacs 29 and 30."
                  (string-trim (buffer-string))))))))
 
 (defun unison-ts--install-grammar ()
-  "Clone the pinned grammar and install it into tree-sitter.
+  "Fetch the pinned grammar revision and install it into tree-sitter.
 `git clone -b' resolves only branch and tag names, never a raw commit
 SHA, so this fetches the revision into a temporary directory and points
 a local branch at it before registering that branch as the source.  The
 branch exists for Emacs 29, which clones the source with `-b'; Emacs 30
-runs `git checkout' in place and would take the SHA directly.
-
-With no revision there is nothing to pin, so treesit clones the
-repository's default branch directly."
+runs `git checkout' in place and would take the SHA directly."
   (if (null unison-ts-grammar-revision)
       (let ((treesit-language-source-alist
              (list (list 'unison unison-ts-grammar-repository))))
         (treesit-install-language-grammar 'unison))
-    (let ((clone-directory (make-temp-file "unison-ts-grammar-" t)))
+    (let ((fetch-directory (make-temp-file "unison-ts-grammar-" t)))
       (unwind-protect
           (progn
             ;; Shallow-fetch just the pinned commit; the full history is
             ;; ~20x the download for one commit.
-            (unison-ts--run-git clone-directory "init" "--quiet")
-            (unison-ts--run-git clone-directory "remote" "add" "origin"
-                                unison-ts-grammar-repository)
-            (unison-ts--run-git clone-directory "fetch" "--quiet" "--depth" "1"
-                                "origin" unison-ts-grammar-revision)
-            (unison-ts--run-git clone-directory "branch"
+            (unison-ts--run-git fetch-directory "init" "--quiet")
+            (unison-ts--run-git fetch-directory "fetch" "--quiet" "--depth" "1"
+                                unison-ts-grammar-repository
+                                unison-ts-grammar-revision)
+            (unison-ts--run-git fetch-directory "branch"
                                 unison-ts--grammar-revision-branch "FETCH_HEAD")
             (let ((treesit-language-source-alist
-                   (list (list 'unison clone-directory
+                   (list (list 'unison fetch-directory
                                unison-ts--grammar-revision-branch))))
               (treesit-install-language-grammar 'unison)))
-        (delete-directory clone-directory t)))))
+        (delete-directory fetch-directory t)))))
 
 (defun unison-ts-install-grammar ()
   "Install tree-sitter grammar for Unison.

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1695,47 +1695,114 @@ the parser routes to the 'add command."
     (should (eq (car parsed) 'add))
     (should (equal (cdr parsed) "foo = 1\nbar = 2"))))
 
-;;; Grammar installation - fail-fast behavior
+;;; Grammar installation - clone the pinned revision, verify availability
 
-(ert-deftest unison-ts-install/propagates-failure ()
-  "A clone/checkout/build failure must propagate, not return nil."
+(defun unison-ts-tests--make-git-fixture ()
+  "Create a throwaway git repo with two commits and return a plist.
+:dir is the repo path; :pinned is the SHA of the first commit, whose
+`marker' file reads \"pinned\".  The second commit changes `marker' to
+\"tip\", so the pinned commit is not the branch tip."
+  (let* ((directory (make-temp-file "unison-ts-fixture-" t))
+         (run-git (lambda (&rest arguments)
+                    (apply #'process-lines "git" "-C" directory arguments))))
+    (funcall run-git "init" "--quiet")
+    (funcall run-git "config" "user.email" "test@example.com")
+    (funcall run-git "config" "user.name" "Test")
+    (with-temp-file (expand-file-name "marker" directory) (insert "pinned"))
+    (funcall run-git "add" "marker")
+    (funcall run-git "commit" "--quiet" "-m" "pinned")
+    (let ((pinned (car (funcall run-git "rev-parse" "HEAD"))))
+      (with-temp-file (expand-file-name "marker" directory) (insert "tip"))
+      (funcall run-git "add" "marker")
+      (funcall run-git "commit" "--quiet" "-m" "tip")
+      (list :dir directory :pinned pinned))))
+
+(ert-deftest unison-ts-install/points-source-branch-at-pinned-revision ()
+  "The helper registers a local source branch resolving to the pinned SHA.
+Emacs 29 clones that branch with `-b' and Emacs 30 checks it out in
+place, both landing on the pinned commit; a raw SHA in the alist would
+break the Emacs 29 clone path, and using the tip would build the wrong
+grammar."
   (require 'unison-ts-install)
   (require 'cl-lib)
-  (let ((treesit-language-source-alist treesit-language-source-alist)
-        (unison-ts--install-prompted nil))
-    (cl-letf (((symbol-function 'treesit-install-language-grammar)
-               (lambda (&rest _) (error "clone failed"))))
-      (should-error (unison-ts-install-grammar) :type 'error))))
+  (let* ((fixture (unison-ts-tests--make-git-fixture))
+         (unison-ts-grammar-repository (plist-get fixture :dir))
+         (unison-ts-grammar-revision (plist-get fixture :pinned))
+         (captured nil))
+    (unwind-protect
+        (progn
+          (cl-letf (((symbol-function 'treesit-install-language-grammar)
+                     (lambda (&rest _)
+                       (let* ((entry (assq 'unison treesit-language-source-alist))
+                              (directory (nth 1 entry))
+                              (branch (nth 2 entry)))
+                         (setq captured
+                               (list :branch branch
+                                     :resolved (car (process-lines
+                                                     "git" "-C" directory
+                                                     "rev-parse" branch))
+                                     :tip (car (process-lines
+                                                "git" "-C" directory
+                                                "rev-parse" "HEAD"))))))))
+            (unison-ts--install-grammar))
+          (should (equal (plist-get captured :branch)
+                         unison-ts--grammar-revision-branch))
+          (should (equal (plist-get captured :resolved) (plist-get fixture :pinned)))
+          (should-not (equal (plist-get captured :resolved)
+                             (plist-get captured :tip))))
+      (delete-directory (plist-get fixture :dir) t))))
 
-(ert-deftest unison-ts-install/error-names-repository ()
-  "The propagated error names the repository and revision for context."
+(ert-deftest unison-ts-install/returns-t-when-grammar-available ()
+  "Install returns t when the grammar is available afterward.
+Revision nil takes the direct path and the stubbed install is a no-op,
+so the return value is driven purely by availability."
   (require 'unison-ts-install)
   (require 'cl-lib)
-  (let ((treesit-language-source-alist treesit-language-source-alist)
-        (unison-ts--install-prompted nil)
-        (unison-ts-grammar-repository "https://example.invalid/grammar")
-        (unison-ts-grammar-revision "abc123"))
+  (let ((unison-ts-grammar-revision nil))
     (cl-letf (((symbol-function 'treesit-install-language-grammar)
-               (lambda (&rest _) (error "clone failed"))))
-      (let ((signaled-message
-             (condition-case err
-                 (progn (unison-ts-install-grammar) nil)
-               (error (error-message-string err)))))
-        (should (equal
-                 signaled-message
-                 (concat "Failed to install Unison grammar from "
-                         "https://example.invalid/grammar (revision abc123): "
-                         "clone failed")))))))
-
-(ert-deftest unison-ts-install/returns-t-on-success ()
-  "A successful install returns t."
-  (require 'unison-ts-install)
-  (require 'cl-lib)
-  (let ((treesit-language-source-alist treesit-language-source-alist)
-        (unison-ts--install-prompted nil))
-    (cl-letf (((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) nil))
+              ((symbol-function 'treesit-language-available-p)
                (lambda (&rest _) t)))
       (should (eq (unison-ts-install-grammar) t)))))
+
+(ert-deftest unison-ts-install/returns-nil-when-grammar-unavailable ()
+  "Install returns nil when the grammar is unavailable afterward.
+This is the demote-to-warning case: the install call completes without
+signaling, yet no grammar was produced."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (let ((unison-ts-grammar-revision nil))
+    (cl-letf (((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) nil))
+              ((symbol-function 'treesit-language-available-p)
+               (lambda (&rest _) nil)))
+      (should (eq (unison-ts-install-grammar) nil)))))
+
+(ert-deftest unison-ts-install/reports-clone-error-and-returns-nil ()
+  "A failed clone is caught, reported once with the git error, and returns nil.
+Emacs demotes treesit's own failures to warnings, but a clone failure
+from `unison-ts--run-git' signals, so this exercises the caught-error
+message path."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (let ((unison-ts-grammar-repository "/unison-ts/does-not-exist")
+        (unison-ts-grammar-revision "662bf52")
+        (logged nil))
+    (cl-letf (((symbol-function 'treesit-language-available-p)
+               (lambda (&rest _) nil))
+              ((symbol-function 'message)
+               (lambda (format-string &rest args)
+                 (push (apply #'format format-string args) logged))))
+      (should (eq (unison-ts-install-grammar) nil)))
+    ;; git's stderr is version- and locale-dependent, so match the stable
+    ;; leading text rather than the full message.
+    (should (seq-some
+             (lambda (line)
+               (string-match-p
+                (concat "\\`Failed to install Unison grammar from "
+                        "/unison-ts/does-not-exist (revision 662bf52): git clone")
+                line))
+             logged))))
 
 (provide 'unison-ts-mode-tests)
 ;;; unison-ts-mode-tests.el ends here

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1695,7 +1695,7 @@ the parser routes to the 'add command."
     (should (eq (car parsed) 'add))
     (should (equal (cdr parsed) "foo = 1\nbar = 2"))))
 
-;;; Grammar installation - clone the pinned revision, verify availability
+;;; Grammar installation - fetch the pinned revision, verify availability
 
 (defun unison-ts-tests--make-git-fixture ()
   "Create a throwaway git repo with two commits and return a plist.
@@ -1753,19 +1753,21 @@ from `unison-ts--run-git' signals, so this exercises the caught-error
 warning path."
   (require 'unison-ts-install)
   (require 'cl-lib)
-  (require 'warnings)
   (let ((unison-ts-grammar-repository "/unison-ts/does-not-exist")
         (unison-ts-grammar-revision "662bf52")
-        (warned nil))
+        (warned nil)
+        (level nil))
     (cl-letf (((symbol-function 'treesit-language-available-p)
                (lambda (&rest _) nil))
               ((symbol-function 'display-warning)
-               (lambda (_type message &rest _) (setq warned message))))
+               (lambda (_type message &optional severity &rest _)
+                 (setq warned message level severity))))
       (should (eq (unison-ts-install-grammar) nil)))
+    (should (eq level :error))
     ;; git's stderr is version- and locale-dependent, so match the stable
     ;; leading text rather than the full message.
-    (should (string-match-p
-             (concat "\\`Failed to install Unison grammar from "
+    (should (string-prefix-p
+             (concat "Failed to install Unison grammar from "
                      "/unison-ts/does-not-exist (revision 662bf52): Git fetch")
              warned))))
 

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1753,6 +1753,9 @@ from `unison-ts--run-git' signals, so this exercises the caught-error
 warning path."
   (require 'unison-ts-install)
   (require 'cl-lib)
+  ;; Load warnings.el before the stub: display-warning is an autoload, and
+  ;; resolving it mid-call replaces the stub with the real function.
+  (require 'warnings)
   (let ((unison-ts-grammar-repository "/unison-ts/does-not-exist")
         (unison-ts-grammar-revision "662bf52")
         (warned nil)

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1726,7 +1726,9 @@ treesit grammar source directly."
          (captured nil))
     (unwind-protect
         (progn
-          (cl-letf (((symbol-function 'treesit-install-language-grammar)
+          (cl-letf (((symbol-function 'treesit-language-available-p)
+                     (lambda (&rest _) t))
+                    ((symbol-function 'treesit-install-language-grammar)
                      (lambda (&rest _)
                        (let* ((entry (assq 'unison treesit-language-source-alist))
                               (directory (nth 1 entry))
@@ -1736,7 +1738,7 @@ treesit grammar source directly."
                                      :resolved (car (process-lines
                                                      "git" "-C" directory
                                                      "rev-parse" branch))))))))
-            (unison-ts--install-grammar))
+            (should (eq (unison-ts-install-grammar) t)))
           (should (equal (plist-get captured :branch)
                          unison-ts--grammar-revision-branch))
           (should (equal (plist-get captured :resolved) (plist-get fixture :pinned)))
@@ -1744,26 +1746,28 @@ treesit grammar source directly."
                              (plist-get fixture :tip))))
       (delete-directory (plist-get fixture :dir) t))))
 
-(ert-deftest unison-ts-install/reports-clone-error-and-returns-nil ()
+(ert-deftest unison-ts-install/reports-fetch-error-and-returns-nil ()
   "A failed fetch is caught, warned about once with the git error, and returns nil.
 Emacs demotes treesit's own failures to warnings, but a fetch failure
 from `unison-ts--run-git' signals, so this exercises the caught-error
 warning path."
   (require 'unison-ts-install)
   (require 'cl-lib)
+  (require 'warnings)
   (let ((unison-ts-grammar-repository "/unison-ts/does-not-exist")
-        (unison-ts-grammar-revision "662bf52"))
-    (when (get-buffer "*Warnings*")
-      (kill-buffer "*Warnings*"))
+        (unison-ts-grammar-revision "662bf52")
+        (warned nil))
     (cl-letf (((symbol-function 'treesit-language-available-p)
-               (lambda (&rest _) nil)))
+               (lambda (&rest _) nil))
+              ((symbol-function 'display-warning)
+               (lambda (_type message &rest _) (setq warned message))))
       (should (eq (unison-ts-install-grammar) nil)))
     ;; git's stderr is version- and locale-dependent, so match the stable
     ;; leading text rather than the full message.
     (should (string-match-p
-             (concat "Error (unison-ts): Failed to install Unison grammar from "
+             (concat "\\`Failed to install Unison grammar from "
                      "/unison-ts/does-not-exist (revision 662bf52): Git fetch")
-             (with-current-buffer "*Warnings*" (buffer-string))))))
+             warned))))
 
 (provide 'unison-ts-mode-tests)
 ;;; unison-ts-mode-tests.el ends here

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1699,30 +1699,25 @@ the parser routes to the 'add command."
 
 (defun unison-ts-tests--make-git-fixture ()
   "Create a throwaway git repo with two commits and return a plist.
-:dir is the repo path; :pinned is the SHA of the first commit, whose
-`marker' file reads \"pinned\".  The second commit changes `marker' to
-\"tip\", so the pinned commit is not the branch tip."
+:dir is the repo path, :pinned is the SHA of the first commit and :tip
+the SHA of the second, so the pinned commit is not the branch tip."
   (let* ((directory (make-temp-file "unison-ts-fixture-" t))
          (run-git (lambda (&rest arguments)
                     (apply #'process-lines "git" "-C" directory arguments))))
     (funcall run-git "init" "--quiet")
     (funcall run-git "config" "user.email" "test@example.com")
     (funcall run-git "config" "user.name" "Test")
-    (with-temp-file (expand-file-name "marker" directory) (insert "pinned"))
-    (funcall run-git "add" "marker")
-    (funcall run-git "commit" "--quiet" "-m" "pinned")
+    (funcall run-git "commit" "--quiet" "--allow-empty" "-m" "pinned")
     (let ((pinned (car (funcall run-git "rev-parse" "HEAD"))))
-      (with-temp-file (expand-file-name "marker" directory) (insert "tip"))
-      (funcall run-git "add" "marker")
-      (funcall run-git "commit" "--quiet" "-m" "tip")
-      (list :dir directory :pinned pinned))))
+      (funcall run-git "commit" "--quiet" "--allow-empty" "-m" "tip")
+      (list :dir directory
+            :pinned pinned
+            :tip (car (funcall run-git "rev-parse" "HEAD"))))))
 
 (ert-deftest unison-ts-install/points-source-branch-at-pinned-revision ()
-  "The helper registers a local source branch resolving to the pinned SHA.
-Emacs 29 clones that branch with `-b' and Emacs 30 checks it out in
-place, both landing on the pinned commit; a raw SHA in the alist would
-break the Emacs 29 clone path, and using the tip would build the wrong
-grammar."
+  "The source branch resolves to the pinned SHA, not the tip.
+See `unison-ts--install-grammar' for why a raw SHA cannot name a
+treesit grammar source directly."
   (require 'unison-ts-install)
   (require 'cl-lib)
   (let* ((fixture (unison-ts-tests--make-git-fixture))
@@ -1740,69 +1735,35 @@ grammar."
                                (list :branch branch
                                      :resolved (car (process-lines
                                                      "git" "-C" directory
-                                                     "rev-parse" branch))
-                                     :tip (car (process-lines
-                                                "git" "-C" directory
-                                                "rev-parse" "HEAD"))))))))
+                                                     "rev-parse" branch))))))))
             (unison-ts--install-grammar))
           (should (equal (plist-get captured :branch)
                          unison-ts--grammar-revision-branch))
           (should (equal (plist-get captured :resolved) (plist-get fixture :pinned)))
           (should-not (equal (plist-get captured :resolved)
-                             (plist-get captured :tip))))
+                             (plist-get fixture :tip))))
       (delete-directory (plist-get fixture :dir) t))))
 
-(ert-deftest unison-ts-install/returns-t-when-grammar-available ()
-  "Install returns t when the grammar is available afterward.
-Revision nil takes the direct path and the stubbed install is a no-op,
-so the return value is driven purely by availability."
-  (require 'unison-ts-install)
-  (require 'cl-lib)
-  (let ((unison-ts-grammar-revision nil))
-    (cl-letf (((symbol-function 'treesit-install-language-grammar)
-               (lambda (&rest _) nil))
-              ((symbol-function 'treesit-language-available-p)
-               (lambda (&rest _) t)))
-      (should (eq (unison-ts-install-grammar) t)))))
-
-(ert-deftest unison-ts-install/returns-nil-when-grammar-unavailable ()
-  "Install returns nil when the grammar is unavailable afterward.
-This is the demote-to-warning case: the install call completes without
-signaling, yet no grammar was produced."
-  (require 'unison-ts-install)
-  (require 'cl-lib)
-  (let ((unison-ts-grammar-revision nil))
-    (cl-letf (((symbol-function 'treesit-install-language-grammar)
-               (lambda (&rest _) nil))
-              ((symbol-function 'treesit-language-available-p)
-               (lambda (&rest _) nil)))
-      (should (eq (unison-ts-install-grammar) nil)))))
-
 (ert-deftest unison-ts-install/reports-clone-error-and-returns-nil ()
-  "A failed clone is caught, reported once with the git error, and returns nil.
-Emacs demotes treesit's own failures to warnings, but a clone failure
+  "A failed fetch is caught, warned about once with the git error, and returns nil.
+Emacs demotes treesit's own failures to warnings, but a fetch failure
 from `unison-ts--run-git' signals, so this exercises the caught-error
-message path."
+warning path."
   (require 'unison-ts-install)
   (require 'cl-lib)
   (let ((unison-ts-grammar-repository "/unison-ts/does-not-exist")
-        (unison-ts-grammar-revision "662bf52")
-        (logged nil))
+        (unison-ts-grammar-revision "662bf52"))
+    (when (get-buffer "*Warnings*")
+      (kill-buffer "*Warnings*"))
     (cl-letf (((symbol-function 'treesit-language-available-p)
-               (lambda (&rest _) nil))
-              ((symbol-function 'message)
-               (lambda (format-string &rest args)
-                 (push (apply #'format format-string args) logged))))
+               (lambda (&rest _) nil)))
       (should (eq (unison-ts-install-grammar) nil)))
     ;; git's stderr is version- and locale-dependent, so match the stable
     ;; leading text rather than the full message.
-    (should (seq-some
-             (lambda (line)
-               (string-match-p
-                (concat "\\`Failed to install Unison grammar from "
-                        "/unison-ts/does-not-exist (revision 662bf52): git clone")
-                line))
-             logged))))
+    (should (string-match-p
+             (concat "Error (unison-ts): Failed to install Unison grammar from "
+                     "/unison-ts/does-not-exist (revision 662bf52): Git fetch")
+             (with-current-buffer "*Warnings*" (buffer-string))))))
 
 (provide 'unison-ts-mode-tests)
 ;;; unison-ts-mode-tests.el ends here


### PR DESCRIPTION
auto-install failed on the pinned commit sha and reported success anyway. emacs hands the revision to `git clone -b`, which resolves only branch and tag names, so cloning a raw sha never worked; treesit then demotes the failure to a warning, so the old condition-case never fired.

- fetch the pinned commit into a temp dir at `--depth 1`, point a local branch at it, register that dir and branch as the grammar source. emacs 30 checks the branch out in place, emacs 29 clones it with `-b`, both land on the pinned commit
- confirm success with `treesit-language-available-p` instead of a signal. failure goes to `display-warning`, so it lands in \*Warnings\* next to treesit's own rather than flashing in the echo area
- require treesit so the special-var let-binding stays dynamic under standalone byte-compilation
- the test builds a real two-commit repo and asserts the registered branch resolves to the pinned sha, not the tip. treesit's own install call is still stubbed

new constraint: a raw-sha pin needs a host that serves unadvertised objects (`uploadpack.allowReachableSHA1InWant`). github does, a self-hosted mirror may not. documented on the `unison-ts-grammar-repository` defcustom; a branch or tag name still fetches from any host.

verified an install on emacs 30.2 and the shallow fetch against the upstream repo. the emacs 29 path is not covered end to end anywhere: CI builds the grammar with its own clone and never calls this code, so the 29.1 and 29.4 jobs only show the unit tests and byte-compile pass there. the `git clone -b` step emacs 29 would run was checked by hand against a shallow local repo on git 2.50.1 and 2.54.0.

Closes #32
