### PR TITLE
fix(install): retry grammar install after a failed attempt

### DIFF
--- a/unison-ts-install.el
+++ b/unison-ts-install.el
@@ -52,8 +52,21 @@ revision against Emacs 29 and 30."
                  (string :tag "Branch/tag/commit"))
   :group 'unison-ts)
 
-(defvar unison-ts--install-prompted nil
-  "Whether we've already prompted for installation this session.")
+(defvar unison-ts--install-declined nil
+  "Non-nil once the user declined the install prompt this session.
+Set only on an explicit \"no\".  Consulted in every mode, so it also
+suppresses a later auto-install this session; a failed install does not
+set it, leaving the user free to be asked again or to retry with
+\\[unison-ts-install-grammar].")
+
+(defvar unison-ts--install-failed nil
+  "Non-nil once an automatic install attempt failed this session.
+Only consulted when `unison-ts-grammar-install' is `auto'.  It stops an
+unattended clone+compile from repeating on every .u buffer opened
+against a persistently broken toolchain; retry with
+\\[unison-ts-install-grammar] after fixing the toolchain.  Never reset:
+once install succeeds the availability check in `unison-ts-ensure-grammar'
+short-circuits, so clearing this flag would be dead code.")
 
 (defconst unison-ts--grammar-revision-branch "unison-ts-pinned-revision"
   "Local branch name pointed at `unison-ts-grammar-revision' during install.")
@@ -117,7 +130,10 @@ that the install call signaled or returned non-nil."
         (progn
           (message "Unison grammar installed successfully")
           t)
-      (message "Failed to install Unison grammar from %s%s%s"
+      (message
+       (concat "Failed to install Unison grammar from %s%s%s.  "
+               "Retry with M-x unison-ts-install-grammar after fixing "
+               "the toolchain.")
                unison-ts-grammar-repository
                (if unison-ts-grammar-revision
                    (format " (revision %s)" unison-ts-grammar-revision)
@@ -135,17 +151,21 @@ installation was declined, disabled, or failed."
    ((treesit-language-available-p 'unison)
     t)
 
-   (unison-ts--install-prompted
+   (unison-ts--install-declined
     nil)
 
    ((eq unison-ts-grammar-install 'auto)
-    (setq unison-ts--install-prompted t)
-    (unison-ts-install-grammar))
+    ;; See `unison-ts--install-failed' for why a failure latches here.
+    (unless unison-ts--install-failed
+      (or (unison-ts-install-grammar)
+          (progn (setq unison-ts--install-failed t) nil))))
 
    ((eq unison-ts-grammar-install 'prompt)
-    (setq unison-ts--install-prompted t)
-    (when (y-or-n-p "Install Unison grammar for syntax highlighting? ")
-      (unison-ts-install-grammar)))
+    ;; Only an explicit decline latches; see `unison-ts--install-declined'.
+    (if (y-or-n-p "Install Unison grammar for syntax highlighting? ")
+        (unison-ts-install-grammar)
+      (setq unison-ts--install-declined t)
+      nil))
 
    (t
     (message "Unison grammar not found. Set unison-ts-grammar-install to enable auto-install.")

--- a/unison-ts-install.el
+++ b/unison-ts-install.el
@@ -22,6 +22,8 @@
 
 ;;; Code:
 
+(require 'treesit)
+
 (defcustom unison-ts-grammar-install 'prompt
   "Control automatic grammar installation.
 - prompt: Ask before installing (default)
@@ -53,36 +55,82 @@ revision against Emacs 29 and 30."
 (defvar unison-ts--install-prompted nil
   "Whether we've already prompted for installation this session.")
 
+(defconst unison-ts--grammar-revision-branch "unison-ts-pinned-revision"
+  "Local branch name pointed at `unison-ts-grammar-revision' during install.")
+
+(defun unison-ts--run-git (directory &rest arguments)
+  "Run git with ARGUMENTS in DIRECTORY, signaling on a non-zero exit."
+  (let ((default-directory (file-name-as-directory directory)))
+    (with-temp-buffer
+      (let ((status (apply #'call-process "git" nil t nil arguments)))
+        (unless (eq status 0)
+          (error "git %s failed: %s"
+                 (string-join arguments " ")
+                 (string-trim (buffer-string))))))))
+
+(defun unison-ts--install-grammar ()
+  "Clone the pinned grammar and install it into tree-sitter.
+Emacs hands `unison-ts-grammar-revision' to `git clone -b', which
+resolves only branch and tag names, so the raw commit SHA the grammar
+is pinned to can never be cloned that way.  Clone the repository into a
+temporary directory, point a local branch at the revision, and register
+that directory and branch as the grammar source.  Emacs 30 checks the
+branch out in place; Emacs 29 clones it with `-b'; both land on the
+pinned commit.
+
+With no revision there is nothing to pin, so treesit clones the
+repository's default branch directly."
+  (if (null unison-ts-grammar-revision)
+      (let ((treesit-language-source-alist
+             (list (list 'unison unison-ts-grammar-repository))))
+        (treesit-install-language-grammar 'unison))
+    (let ((clone-directory (make-temp-file "unison-ts-grammar-" t)))
+      (unwind-protect
+          (progn
+            ;; Full clone, not --depth 1: the pinned revision predates the
+            ;; default-branch tip, so a shallow clone would not contain the
+            ;; object `git branch' needs to point at.
+            (unison-ts--run-git clone-directory
+                                "clone" unison-ts-grammar-repository ".")
+            (unison-ts--run-git clone-directory "branch"
+                                unison-ts--grammar-revision-branch
+                                unison-ts-grammar-revision)
+            (let ((treesit-language-source-alist
+                   (list (list 'unison clone-directory
+                               unison-ts--grammar-revision-branch))))
+              (treesit-install-language-grammar 'unison)))
+        (delete-directory clone-directory t)))))
+
 (defun unison-ts-install-grammar ()
   "Install tree-sitter grammar for Unison.
-Signal an error if cloning, checkout, or building the grammar fails;
-the grammar is pinned to a specific revision and a partial install
-would silently degrade syntax highlighting."
+Return t if the grammar is available afterward, nil otherwise.  Emacs
+demotes tree-sitter install failures to warnings, so success is
+confirmed with `treesit-language-available-p' rather than by trusting
+that the install call signaled or returned non-nil."
   (interactive)
-  (unless (assoc 'unison treesit-language-source-alist)
-    (add-to-list 'treesit-language-source-alist
-                 (if unison-ts-grammar-revision
-                     (list 'unison unison-ts-grammar-repository unison-ts-grammar-revision)
-                   (list 'unison unison-ts-grammar-repository))))
   (message "Installing Unison grammar...")
-  (condition-case err
-      (progn
-        (treesit-install-language-grammar 'unison)
-        (message "Unison grammar installed successfully")
-        t)
-    (error
-     (signal (car err)
-             (list (format "Failed to install Unison grammar from %s%s: %s"
-                           unison-ts-grammar-repository
-                           (if unison-ts-grammar-revision
-                               (format " (revision %s)" unison-ts-grammar-revision)
-                             "")
-                           (error-message-string err)))))))
+  (let ((install-error
+         (condition-case err
+             (progn (unison-ts--install-grammar) nil)
+           (error (error-message-string err)))))
+    (if (treesit-language-available-p 'unison)
+        (progn
+          (message "Unison grammar installed successfully")
+          t)
+      (message "Failed to install Unison grammar from %s%s%s"
+               unison-ts-grammar-repository
+               (if unison-ts-grammar-revision
+                   (format " (revision %s)" unison-ts-grammar-revision)
+                 "")
+               (if install-error
+                   (format ": %s" install-error)
+                 "; see the tree-sitter error in the *Warnings* buffer"))
+      nil)))
 
 (defun unison-ts-ensure-grammar ()
   "Ensure tree-sitter grammar for Unison is installed.
-Return t if grammar is available, nil if installation was declined or
-disabled.  Signal an error if an attempted installation fails."
+Return t if the grammar is available, nil if it is unavailable and
+installation was declined, disabled, or failed."
   (cond
    ((treesit-language-available-p 'unison)
     t)

--- a/unison-ts-install.el
+++ b/unison-ts-install.el
@@ -69,8 +69,8 @@ Only consulted when `unison-ts-grammar-install' is `auto'.  It stops an
 unattended clone+compile from repeating on every .u buffer opened
 against a persistently broken toolchain; retry with
 \\[unison-ts-install-grammar] after fixing the toolchain.  Never reset:
-once install succeeds the availability check in `unison-ts-ensure-grammar'
-short-circuits, so clearing this flag would be dead code.")
+a successful install short-circuits `unison-ts-ensure-grammar' before
+this flag is checked again.")
 
 (defconst unison-ts--grammar-revision-branch "unison-ts-pinned-revision"
   "Local branch name pointed at `unison-ts-grammar-revision' during install.")
@@ -155,6 +155,8 @@ installation was declined, disabled, or failed."
    ((treesit-language-available-p 'unison)
     t)
 
+   ;; Must precede the mode arms so a decline suppresses a later
+   ;; auto-install too; see `unison-ts--install-declined'.
    (unison-ts--install-declined
     nil)
 

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1804,5 +1804,128 @@ message path."
                 line))
              logged))))
 
+;;; Grammar installation - session latch after decline / failure
+;;
+;; These drive the real `unison-ts-install-grammar' and stub only its
+;; external boundary (`treesit-install-language-grammar' installs,
+;; `treesit-language-available-p' confirms), matching the convention of
+;; the availability tests above.  `unison-ts-grammar-revision' is nil so
+;; install takes the direct path and never shells out to git.
+
+(ert-deftest unison-ts-install/does-not-reprompt-after-decline ()
+  "An explicit decline latches the prompt off for the rest of the session."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (let ((unison-ts-grammar-install 'prompt)
+        (unison-ts-grammar-revision nil)
+        (unison-ts--install-declined nil)
+        (unison-ts--install-failed nil)
+        (prompts 0))
+    (cl-letf (((symbol-function 'treesit-language-available-p)
+               (lambda (&rest _) nil))
+              ((symbol-function 'y-or-n-p)
+               (lambda (&rest _) (cl-incf prompts) nil))
+              ((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) (error "install must not run after a decline"))))
+      (should-not (unison-ts-ensure-grammar))
+      (should-not (unison-ts-ensure-grammar))
+      (should (= prompts 1)))))
+
+(ert-deftest unison-ts-install/reprompts-after-a-failed-install ()
+  "A failed install does not latch; see `unison-ts--install-declined'."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (let ((unison-ts-grammar-install 'prompt)
+        (unison-ts-grammar-revision nil)
+        (unison-ts--install-declined nil)
+        (unison-ts--install-failed nil)
+        (prompts 0)
+        (installs 0))
+    (cl-letf (((symbol-function 'treesit-language-available-p)
+               (lambda (&rest _) nil))
+              ((symbol-function 'y-or-n-p)
+               (lambda (&rest _) (cl-incf prompts) t))
+              ((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) (cl-incf installs))))
+      (should-not (unison-ts-ensure-grammar))
+      (should-not (unison-ts-ensure-grammar))
+      (should (= prompts 2))
+      (should (= installs 2)))))
+
+(ert-deftest unison-ts-install/does-not-reattempt-auto-install-after-failure ()
+  "Auto mode latches off after a failed install; see `unison-ts--install-failed'."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (let ((unison-ts-grammar-install 'auto)
+        (unison-ts-grammar-revision nil)
+        (unison-ts--install-declined nil)
+        (unison-ts--install-failed nil)
+        (installs 0))
+    (cl-letf (((symbol-function 'treesit-language-available-p)
+               (lambda (&rest _) nil))
+              ((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) (cl-incf installs))))
+      (should-not (unison-ts-ensure-grammar))
+      (should-not (unison-ts-ensure-grammar))
+      (should (= installs 1)))))
+
+(ert-deftest unison-ts-install/auto-install-success-returns-t ()
+  "A successful auto install reports availability without latching anything."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (let ((unison-ts-grammar-install 'auto)
+        (unison-ts-grammar-revision nil)
+        (unison-ts--install-declined nil)
+        (unison-ts--install-failed nil)
+        (installed nil))
+    (cl-letf (((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) (setq installed t)))
+              ((symbol-function 'treesit-language-available-p)
+               (lambda (&rest _) installed)))
+      (should (eq (unison-ts-ensure-grammar) t))
+      (should-not unison-ts--install-failed))))
+
+(ert-deftest unison-ts-install/failure-message-names-the-manual-retry ()
+  "A failed install points the user at the M-x retry command.
+The hint is the only place an `auto'-mode user, whose buffer degrades
+silently once `unison-ts--install-failed' latches, learns how to retry
+after fixing the toolchain."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (let ((unison-ts-grammar-revision nil)
+        (logged nil))
+    (cl-letf (((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) nil))
+              ((symbol-function 'treesit-language-available-p)
+               (lambda (&rest _) nil))
+              ((symbol-function 'message)
+               (lambda (format-string &rest args)
+                 (push (apply #'format format-string args) logged))))
+      (should-not (unison-ts-install-grammar)))
+    (should (seq-some
+             (lambda (line)
+               (string-match-p "M-x unison-ts-install-grammar" line))
+             logged))))
+
+(ert-deftest unison-ts-install/decline-suppresses-later-auto-install ()
+  "A decline latches across modes; see `unison-ts--install-declined'."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (let ((unison-ts-grammar-install 'prompt)
+        (unison-ts-grammar-revision nil)
+        (unison-ts--install-declined nil)
+        (unison-ts--install-failed nil)
+        (installs 0))
+    (cl-letf (((symbol-function 'treesit-language-available-p)
+               (lambda (&rest _) nil))
+              ((symbol-function 'y-or-n-p)
+               (lambda (&rest _) nil))
+              ((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) (cl-incf installs))))
+      (should-not (unison-ts-ensure-grammar))
+      (setq unison-ts-grammar-install 'auto)
+      (should-not (unison-ts-ensure-grammar))
+      (should (= installs 0)))))
+
 (provide 'unison-ts-mode-tests)
 ;;; unison-ts-mode-tests.el ends here

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1695,47 +1695,114 @@ the parser routes to the 'add command."
     (should (eq (car parsed) 'add))
     (should (equal (cdr parsed) "foo = 1\nbar = 2"))))
 
-;;; Grammar installation - fail-fast behavior
+;;; Grammar installation - clone the pinned revision, verify availability
 
-(ert-deftest unison-ts-install/propagates-failure ()
-  "A clone/checkout/build failure must propagate, not return nil."
+(defun unison-ts-tests--make-git-fixture ()
+  "Create a throwaway git repo with two commits and return a plist.
+:dir is the repo path; :pinned is the SHA of the first commit, whose
+`marker' file reads \"pinned\".  The second commit changes `marker' to
+\"tip\", so the pinned commit is not the branch tip."
+  (let* ((directory (make-temp-file "unison-ts-fixture-" t))
+         (run-git (lambda (&rest arguments)
+                    (apply #'process-lines "git" "-C" directory arguments))))
+    (funcall run-git "init" "--quiet")
+    (funcall run-git "config" "user.email" "test@example.com")
+    (funcall run-git "config" "user.name" "Test")
+    (with-temp-file (expand-file-name "marker" directory) (insert "pinned"))
+    (funcall run-git "add" "marker")
+    (funcall run-git "commit" "--quiet" "-m" "pinned")
+    (let ((pinned (car (funcall run-git "rev-parse" "HEAD"))))
+      (with-temp-file (expand-file-name "marker" directory) (insert "tip"))
+      (funcall run-git "add" "marker")
+      (funcall run-git "commit" "--quiet" "-m" "tip")
+      (list :dir directory :pinned pinned))))
+
+(ert-deftest unison-ts-install/points-source-branch-at-pinned-revision ()
+  "The helper registers a local source branch resolving to the pinned SHA.
+Emacs 29 clones that branch with `-b' and Emacs 30 checks it out in
+place, both landing on the pinned commit; a raw SHA in the alist would
+break the Emacs 29 clone path, and using the tip would build the wrong
+grammar."
   (require 'unison-ts-install)
   (require 'cl-lib)
-  (let ((treesit-language-source-alist treesit-language-source-alist)
-        (unison-ts--install-prompted nil))
-    (cl-letf (((symbol-function 'treesit-install-language-grammar)
-               (lambda (&rest _) (error "clone failed"))))
-      (should-error (unison-ts-install-grammar) :type 'error))))
+  (let* ((fixture (unison-ts-tests--make-git-fixture))
+         (unison-ts-grammar-repository (plist-get fixture :dir))
+         (unison-ts-grammar-revision (plist-get fixture :pinned))
+         (captured nil))
+    (unwind-protect
+        (progn
+          (cl-letf (((symbol-function 'treesit-install-language-grammar)
+                     (lambda (&rest _)
+                       (let* ((entry (assq 'unison treesit-language-source-alist))
+                              (directory (nth 1 entry))
+                              (branch (nth 2 entry)))
+                         (setq captured
+                               (list :branch branch
+                                     :resolved (car (process-lines
+                                                     "git" "-C" directory
+                                                     "rev-parse" branch))
+                                     :tip (car (process-lines
+                                                "git" "-C" directory
+                                                "rev-parse" "HEAD"))))))))
+            (unison-ts--install-grammar))
+          (should (equal (plist-get captured :branch)
+                         unison-ts--grammar-revision-branch))
+          (should (equal (plist-get captured :resolved) (plist-get fixture :pinned)))
+          (should-not (equal (plist-get captured :resolved)
+                             (plist-get captured :tip))))
+      (delete-directory (plist-get fixture :dir) t))))
 
-(ert-deftest unison-ts-install/error-names-repository ()
-  "The propagated error names the repository and revision for context."
+(ert-deftest unison-ts-install/returns-t-when-grammar-available ()
+  "Install returns t when the grammar is available afterward.
+Revision nil takes the direct path and the stubbed install is a no-op,
+so the return value is driven purely by availability."
   (require 'unison-ts-install)
   (require 'cl-lib)
-  (let ((treesit-language-source-alist treesit-language-source-alist)
-        (unison-ts--install-prompted nil)
-        (unison-ts-grammar-repository "https://example.invalid/grammar")
-        (unison-ts-grammar-revision "abc123"))
+  (let ((unison-ts-grammar-revision nil))
     (cl-letf (((symbol-function 'treesit-install-language-grammar)
-               (lambda (&rest _) (error "clone failed"))))
-      (let ((signaled-message
-             (condition-case err
-                 (progn (unison-ts-install-grammar) nil)
-               (error (error-message-string err)))))
-        (should (equal
-                 signaled-message
-                 (concat "Failed to install Unison grammar from "
-                         "https://example.invalid/grammar (revision abc123): "
-                         "clone failed")))))))
-
-(ert-deftest unison-ts-install/returns-t-on-success ()
-  "A successful install returns t."
-  (require 'unison-ts-install)
-  (require 'cl-lib)
-  (let ((treesit-language-source-alist treesit-language-source-alist)
-        (unison-ts--install-prompted nil))
-    (cl-letf (((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) nil))
+              ((symbol-function 'treesit-language-available-p)
                (lambda (&rest _) t)))
       (should (eq (unison-ts-install-grammar) t)))))
+
+(ert-deftest unison-ts-install/returns-nil-when-grammar-unavailable ()
+  "Install returns nil when the grammar is unavailable afterward.
+This is the demote-to-warning case: the install call completes without
+signaling, yet no grammar was produced."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (let ((unison-ts-grammar-revision nil))
+    (cl-letf (((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) nil))
+              ((symbol-function 'treesit-language-available-p)
+               (lambda (&rest _) nil)))
+      (should (eq (unison-ts-install-grammar) nil)))))
+
+(ert-deftest unison-ts-install/reports-clone-error-and-returns-nil ()
+  "A failed clone is caught, reported once with the git error, and returns nil.
+Emacs demotes treesit's own failures to warnings, but a clone failure
+from `unison-ts--run-git' signals, so this exercises the caught-error
+message path."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (let ((unison-ts-grammar-repository "/unison-ts/does-not-exist")
+        (unison-ts-grammar-revision "662bf52")
+        (logged nil))
+    (cl-letf (((symbol-function 'treesit-language-available-p)
+               (lambda (&rest _) nil))
+              ((symbol-function 'message)
+               (lambda (format-string &rest args)
+                 (push (apply #'format format-string args) logged))))
+      (should (eq (unison-ts-install-grammar) nil)))
+    ;; git's stderr is version- and locale-dependent, so match the stable
+    ;; leading text rather than the full message.
+    (should (seq-some
+             (lambda (line)
+               (string-match-p
+                (concat "\\`Failed to install Unison grammar from "
+                        "/unison-ts/does-not-exist (revision 662bf52): git clone")
+                line))
+             logged))))
 
 (provide 'unison-ts-mode-tests)
 ;;; unison-ts-mode-tests.el ends here

--- a/unison-ts-mode-tests.el
+++ b/unison-ts-mode-tests.el
@@ -1797,6 +1797,7 @@ warning path."
   "A failed install does not latch; see `unison-ts--install-declined'."
   (require 'unison-ts-install)
   (require 'cl-lib)
+  (require 'warnings)
   (let ((unison-ts-grammar-install 'prompt)
         (unison-ts-grammar-revision nil)
         (unison-ts--install-declined nil)
@@ -1807,6 +1808,8 @@ warning path."
                (lambda (&rest _) nil))
               ((symbol-function 'y-or-n-p)
                (lambda (&rest _) (cl-incf prompts) t))
+              ((symbol-function 'display-warning)
+               (lambda (&rest _) nil))
               ((symbol-function 'treesit-install-language-grammar)
                (lambda (&rest _) (cl-incf installs))))
       (should-not (unison-ts-ensure-grammar))
@@ -1818,12 +1821,15 @@ warning path."
   "Auto mode latches off after a failed install; see `unison-ts--install-failed'."
   (require 'unison-ts-install)
   (require 'cl-lib)
+  (require 'warnings)
   (let ((unison-ts-grammar-install 'auto)
         (unison-ts-grammar-revision nil)
         (unison-ts--install-declined nil)
         (unison-ts--install-failed nil)
         (installs 0))
     (cl-letf (((symbol-function 'treesit-language-available-p)
+               (lambda (&rest _) nil))
+              ((symbol-function 'display-warning)
                (lambda (&rest _) nil))
               ((symbol-function 'treesit-install-language-grammar)
                (lambda (&rest _) (cl-incf installs))))
@@ -1849,9 +1855,8 @@ warning path."
 
 (ert-deftest unison-ts-install/failure-warning-names-the-manual-retry ()
   "A failed install points the user at the M-x retry command.
-The hint is the only place an `auto'-mode user, whose buffer degrades
-silently once `unison-ts--install-failed' latches, learns how to retry
-after fixing the toolchain."
+The only place an `auto'-mode user, who otherwise degrades silently,
+learns how to retry after fixing the toolchain."
   (require 'unison-ts-install)
   (require 'cl-lib)
   ;; Load warnings.el before the stub: display-warning is an autoload, and
@@ -1887,6 +1892,33 @@ after fixing the toolchain."
       (setq unison-ts-grammar-install 'auto)
       (should-not (unison-ts-ensure-grammar))
       (should (= installs 0)))))
+
+(ert-deftest unison-ts-install/auto-failure-does-not-suppress-later-prompt ()
+  "The auto-failure latch is auto-only, unlike a decline; see
+`unison-ts--install-declined' and `unison-ts--install-failed'."
+  (require 'unison-ts-install)
+  (require 'cl-lib)
+  (require 'warnings)
+  (let ((unison-ts-grammar-install 'auto)
+        (unison-ts-grammar-revision nil)
+        (unison-ts--install-declined nil)
+        (unison-ts--install-failed nil)
+        (prompts 0)
+        (installs 0))
+    (cl-letf (((symbol-function 'treesit-language-available-p)
+               (lambda (&rest _) nil))
+              ((symbol-function 'y-or-n-p)
+               (lambda (&rest _) (cl-incf prompts) t))
+              ((symbol-function 'display-warning)
+               (lambda (&rest _) nil))
+              ((symbol-function 'treesit-install-language-grammar)
+               (lambda (&rest _) (cl-incf installs))))
+      (should-not (unison-ts-ensure-grammar))
+      (should unison-ts--install-failed)
+      (setq unison-ts-grammar-install 'prompt)
+      (should-not (unison-ts-ensure-grammar))
+      (should (= prompts 1))
+      (should (= installs 2)))))
 
 (provide 'unison-ts-mode-tests)
 ;;; unison-ts-mode-tests.el ends here


### PR DESCRIPTION
stacks on #33, lands after it.

`unison-ts-ensure-grammar` latched one `install-prompted` flag before attempting install. since #33 made install return nil on failure instead of signaling, a transient failure quietly degraded the buffer and the latch blocked every retry for the session.

split the latch by outcome:
- explicit decline sets `install-declined` and never re-prompts (consulted in every mode)
- prompt mode does not latch on failure; the next buffer open asks again and the user gates each clone+compile
- auto mode sets `install-failed` on failure so an unattended clone+compile does not repeat on every buffer open against a broken toolchain
- the failure message now names `M-x unison-ts-install-grammar` as the manual retry

tests stub the external boundary (`treesit-install-language-grammar`, `treesit-language-available-p`), not our own install function. six ert cases cover decline, prompt re-ask after failure, auto latch after failure, auto success, the cross-mode decline-then-auto latch, and the retry-hint message. full suite green (202), byte-compile clean, pre-commit clean.
